### PR TITLE
Mat 4527 measure bundle with population association

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 		<dependency>
 			<groupId>gov.cms.madie</groupId>
 			<artifactId>madie-java-models</artifactId>
-			<version>0.2.0-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
@@ -1,29 +1,43 @@
 package gov.cms.madie.madiefhirservice.services;
 
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import ca.uhn.fhir.model.primitive.StringDt;
 import gov.cms.madie.madiefhirservice.constants.UriConstants;
+import gov.cms.madie.models.measure.AssociationType;
 import gov.cms.madie.models.measure.Group;
 import gov.cms.madie.models.measure.Measure;
+import gov.cms.madie.models.measure.Population;
+import gov.cms.madie.models.measure.PopulationType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.ContactDetail;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Expression;
+import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.Type;
+import org.hl7.fhir.r4.model.codesystems.MeasurePopulation;
+import org.hl7.fhir.r4.model.codesystems.MeasureType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-
+import javax.persistence.Tuple;
 import static org.hl7.fhir.r4.model.Measure.MeasureGroupComponent;
 import static org.hl7.fhir.r4.model.Measure.MeasureGroupPopulationComponent;
 
@@ -67,6 +81,8 @@ public class MeasureTranslatorService {
   }
 
   public List<MeasureGroupComponent> buildFhirPopulationGroups(List<Group> madieGroups) {
+
+
     return madieGroups.stream()
       .map(this::buildFhirPopulationGroup)
       .collect(Collectors.toList());
@@ -74,19 +90,47 @@ public class MeasureTranslatorService {
 
   public MeasureGroupComponent buildFhirPopulationGroup(Group madieGroup) {
     List<MeasureGroupPopulationComponent> measurePopulations = madieGroup.getPopulations()
-      .stream()
+      .stream().sorted(Population::compareTo)
       .map(population -> {
         String populationCode = population.getName().toCode();
-        String populationDisplay = population.getName().getDisplay();
+        String  populationDisplay = population.getName().getDisplay();
         return (MeasureGroupPopulationComponent)(new MeasureGroupPopulationComponent()
           .setCode(buildCodeableConcept(populationCode, UriConstants.POPULATION_SYSTEM_URI, populationDisplay))
           .setCriteria(buildExpression("text/cql.identifier", population.getDefinition()))
-          .setId(population.getId()));
+          .setId(population.getId()))
+          .addExtension(buildPopulationTypeExtension(population, madieGroup));
         // TODO: Add an extension for measure observations
       }).collect(Collectors.toList());
 
     return (MeasureGroupComponent)(new MeasureGroupComponent().setPopulation(measurePopulations)
         .setId(madieGroup.getId()));
+  }
+
+  private Extension buildPopulationTypeExtension(Population population, Group madieGroup) {
+    //TODO: I feel like this should be in a QICore specific module
+    Extension extension = null;
+    AtomicReference<String> id  = new AtomicReference<String>();
+    if (population.getName().equals( PopulationType.INITIAL_POPULATION)) {
+        //then get associationType and find the group.populatino that matches and give it the ID
+        AssociationType associationType = population.getAssociationType();
+        madieGroup.getPopulations().forEach(pop -> {          
+          if (associationType != null && 
+              pop.getName().toCode().equalsIgnoreCase(associationType.toString())) {
+            pop.setReferenceId(population.getId());            
+          }
+        });
+        
+    }
+    else if (population.getName().equals( PopulationType.DENOMINATOR) ||
+        population.getName().equals( PopulationType.NUMERATOR)) {
+      IBaseDatatype theValue = new StringType(population.getReferenceId());
+      //TODO investigate whether these URLS can change; 
+      //  if they are codified in HAPI FHIR Libraries.. 
+      //  we should define a separate property file with this list 
+      extension = new Extension("http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference", theValue) ;
+    }
+    //value is a codeable concept
+    return extension;
   }
 
   public Expression buildExpression(String language, String expression) {
@@ -115,7 +159,7 @@ public class MeasureTranslatorService {
   public CodeableConcept buildCodeableConcept(String code, String system, String display) {
     CodeableConcept codeableConcept = new CodeableConcept();
     codeableConcept.setCoding(new ArrayList<>());
-    codeableConcept.getCoding()
+    codeableConcept.getCoding()  
       .add(buildCoding(code, system, display));
     return codeableConcept;
   }

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorServiceTest.java
@@ -70,14 +70,14 @@ public class MeasureTranslatorServiceTest implements ResourceFileUtil {
       is(equalTo("01/01/2023")));
     assertThat(DateFormatUtils.format(measure.getEffectivePeriod().getEnd(), "MM/dd/yyyy"),
       is(equalTo("12/31/2023")));
-    assertThat(measure.getMeta().getProfile().get(0).getValue(), is(equalTo(UriConstants.PROPORTION_PROFILE_URI)));
+    assertThat(measure.getMeta().getProfile().get(0).getValue(), is(equalTo(UriConstants.RATIO_PROFILE_URI)));
     assertThat(measure.getGroup().size(), is(equalTo(madieMeasure.getGroups().size())));
 
     assertThat(measure.getGroup().get(0).getId(), is(notNullValue()));
 
     MeasureGroupPopulationComponent groupComponent = measure.getGroup().get(0).getPopulation().get(0);
     assertThat(groupComponent.getCriteria().getLanguage(), is(equalTo("text/cql.identifier")));
-    assertThat(groupComponent.getCriteria().getExpression(), is(equalTo("ipp")));
+    assertThat(groupComponent.getCriteria().getExpression(), is(equalTo("SDE Ethnicity")));
     assertThat(groupComponent.getCode().getCoding().get(0).getDisplay(), is(equalTo("Initial Population")));
     assertThat(groupComponent.getCode().getCoding().get(0).getCode(), is(equalTo("initial-population")));
     assertThat(groupComponent.getId(), is(notNullValue()));
@@ -98,13 +98,13 @@ public class MeasureTranslatorServiceTest implements ResourceFileUtil {
     assertThat(measure.getRationale(),
         is(equalTo(madieMeasure.getMeasureMetaData().getRationale())));
     assertThat(measure.getPublisher(), is(equalTo("UNKNOWN")));
-    assertThat(measure.getUrl(), is(equalTo("cms.gov/Measure/"+ madieMeasure.getCqlLibraryName())));
+    assertThat(measure.getUrl(), is(equalTo("cms.gov/Measure/"+ madieRatioMeasure.getCqlLibraryName())));
     assertThat(DateFormatUtils.format(measure.getEffectivePeriod().getStart(), "MM/dd/yyyy"),
         is(equalTo("01/01/2023")));
     assertThat(DateFormatUtils.format(measure.getEffectivePeriod().getEnd(), "MM/dd/yyyy"),
         is(equalTo("12/31/2023")));
     assertThat(measure.getMeta().getProfile().get(0).getValue(), is(equalTo(UriConstants.RATIO_PROFILE_URI)));
-    assertThat(measure.getGroup().size(), is(equalTo(madieMeasure.getGroups().size())));
+    assertThat(measure.getGroup().size(), is(equalTo(madieRatioMeasure.getGroups().size())));
 
     assertThat(measure.getGroup().get(0).getId(), is(notNullValue()));
 

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorServiceTest.java
@@ -4,8 +4,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.cms.madie.madiefhirservice.constants.UriConstants;
 import gov.cms.madie.madiefhirservice.utils.MeasureTestHelper;
 import gov.cms.madie.madiefhirservice.utils.ResourceFileUtil;
+import gov.cms.madie.models.measure.AssociationType;
+import gov.cms.madie.models.measure.Group;
 import gov.cms.madie.models.measure.Measure;
+import gov.cms.madie.models.measure.MeasureScoring;
+import gov.cms.madie.models.measure.Population;
+import gov.cms.madie.models.measure.PopulationType;
 import org.apache.commons.lang3.time.DateFormatUtils;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Measure.MeasureGroupComponent;
+import org.hl7.fhir.r4.model.Measure.MeasureGroupPopulationComponent;
 import org.hl7.fhir.r4.model.Meta;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,12 +22,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-
+import static org.assertj.core.api.Assertions.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hl7.fhir.r4.model.Measure.MeasureGroupPopulationComponent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 public class MeasureTranslatorServiceTest implements ResourceFileUtil {
@@ -125,5 +140,72 @@ public class MeasureTranslatorServiceTest implements ResourceFileUtil {
     // Meta for Ratio Scoring
     meta = measureTranslatorService.buildMeasureMeta("Ratio");
     assertThat(meta.getProfile().get(0).getValue(), is(equalTo(UriConstants.RATIO_PROFILE_URI)));
+  }
+  
+  @Test
+  public void testBuildFhirPopulationGroupsWithAssocations() {
+    Population ip1 = new Population() ; 
+    ip1.setName(PopulationType.INITIAL_POPULATION);
+    ip1.setAssociationType(AssociationType.DENOMINATOR);
+    ip1.setId("initial-population-1");
+    Population ip2 = new Population() ; 
+    ip2.setName(PopulationType.INITIAL_POPULATION);
+    ip2.setAssociationType(AssociationType.NUMERATOR);
+    ip2.setId("initial-population-2");
+    Population denom = new Population() ; 
+    denom.setName(PopulationType.DENOMINATOR);
+    Population numer = new Population() ; 
+    numer.setName(PopulationType.NUMERATOR);
+    Group group = new Group() ; 
+    group.setScoring(MeasureScoring.RATIO.toString());
+    List<Population> pops = new ArrayList<>();
+    pops.add(numer);
+    pops.add(denom);
+    pops.add(ip1);
+    pops.add(ip2);
+    group.setPopulations(pops);
+    List<Group> groups = new ArrayList<>();
+    groups.add(group);
+    
+    List<MeasureGroupComponent> groupComponent = measureTranslatorService.buildFhirPopulationGroups(groups);
+    assertNotNull(groupComponent);
+    String numeratorId = null ; 
+    String denominatorId = null ; 
+    groupComponent.forEach((mgc) -> {
+      List<MeasureGroupPopulationComponent> gpcs = mgc.getPopulation();
+      gpcs.forEach((gpc) -> {
+        CodeableConcept code = gpc.getCode();
+        code.getCoding().forEach(coding -> {
+          switch(coding.getCode()) {
+            case "denominator" :
+              //this needs to be associated with denominator IP
+              Extension ext2 = gpc.getExtensionByUrl("http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference");
+              assertNotNull(ext2);
+              assertEquals("initial-population-1", ext2.getValue().toString());
+              break ;
+            case "numerator" :
+              //this needs to be associated with numerator IP
+              Extension ext1 = gpc.getExtensionByUrl("http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference");
+              assertNotNull(ext1);
+              assertEquals("initial-population-2", ext1.getValue().toString());
+              break ;            
+            case "initial-population":
+              //get associationType
+              Extension ext3 = gpc.getExtensionByUrl("http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference");
+              assertNull(ext3);
+              break ; 
+            default : 
+              System.out.println(coding.getCode());
+              break ; 
+          }
+          
+        });
+
+      });
+    });
+    
+    
+    
+    
   }
 }

--- a/src/test/resources/measures/SimpleFhirMeasureLib/madie_measure.json
+++ b/src/test/resources/measures/SimpleFhirMeasureLib/madie_measure.json
@@ -1,39 +1,201 @@
 {
-  "id": "626be3ca0ca8110d3b22404a",
-  "cqlLibraryName": "SimpleFhirMeasureLib",
-  "measureName": "SimpleFhirMeasure",
-  "cql": "library SimpleFhirMeasureLib version '0.0.004'\n\nusing FHIR version '4.0.1'\n\ninclude FHIRHelpers version '4.0.001' called FHIRHelpers\n\nparameter \"Measurement Period\" Interval<DateTime>\n\ncontext Patient\n\ndefine \"ipp\":\n  exists [\"Encounter\"] E where E.period.start during \"Measurement Period\"\n\ndefine \"denom\":\n  \"ipp\"\n\ndefine \"num\":\n  exists [\"Encounter\"] E where E.status ~ 'finished'",
-  "elmJson": "{\"library\":{\"identifier\":{\"id\":\"SimpleFhirMeasureLib\",\"version\":\"0.0.004\"},\"schemaIdentifier\":{\"id\":\"urn:hl7-org:elm\",\"version\":\"r1\"},\"usings\":{\"def\":[{\"localIdentifier\":\"System\",\"uri\":\"urn:hl7-org:elm-types:r1\"},{\"localId\":\"1\",\"locator\":\"3:1-3:26\",\"localIdentifier\":\"FHIR\",\"uri\":\"http://hl7.org/fhir\",\"version\":\"4.0.1\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"1\",\"s\":[{\"value\":[\"\",\"using \"]},{\"s\":[{\"value\":[\"FHIR\"]}]},{\"value\":[\" version \",\"'4.0.1'\"]}]}}]}]},\"includes\":{\"def\":[{\"localId\":\"2\",\"locator\":\"5:1-5:56\",\"localIdentifier\":\"FHIRHelpers\",\"path\":\"FHIRHelpers\",\"version\":\"4.0.001\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"2\",\"s\":[{\"value\":[\"\",\"include \"]},{\"s\":[{\"value\":[\"FHIRHelpers\"]}]},{\"value\":[\" version \",\"'4.0.001'\",\" called \",\"FHIRHelpers\"]}]}}]}]},\"parameters\":{\"def\":[{\"localId\":\"5\",\"locator\":\"7:1-7:49\",\"name\":\"Measurement Period\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"5\",\"s\":[{\"value\":[\"\",\"parameter \",\"\\\"Measurement Period\\\"\",\" \"]},{\"r\":\"4\",\"s\":[{\"value\":[\"Interval<\"]},{\"r\":\"3\",\"s\":[{\"value\":[\"DateTime\"]}]},{\"value\":[\">\"]}]}]}}],\"parameterTypeSpecifier\":{\"localId\":\"4\",\"locator\":\"7:32-7:49\",\"type\":\"IntervalTypeSpecifier\",\"pointType\":{\"localId\":\"3\",\"locator\":\"7:41-7:48\",\"name\":\"{urn:hl7-org:elm-types:r1}DateTime\",\"type\":\"NamedTypeSpecifier\"}}}]},\"contexts\":{\"def\":[{\"locator\":\"9:1-9:15\",\"name\":\"Patient\"}]},\"statements\":{\"def\":[{\"locator\":\"9:1-9:15\",\"name\":\"Patient\",\"context\":\"Patient\",\"expression\":{\"type\":\"SingletonFrom\",\"operand\":{\"locator\":\"9:1-9:15\",\"dataType\":\"{http://hl7.org/fhir}Patient\",\"templateId\":\"http://hl7.org/fhir/StructureDefinition/Patient\",\"type\":\"Retrieve\"}}},{\"localId\":\"15\",\"locator\":\"11:1-12:73\",\"name\":\"ipp\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"15\",\"s\":[{\"value\":[\"\",\"define \",\"\\\"ipp\\\"\",\":\\n  \"]},{\"r\":\"14\",\"s\":[{\"value\":[\"exists \"]},{\"r\":\"13\",\"s\":[{\"s\":[{\"r\":\"7\",\"s\":[{\"r\":\"6\",\"s\":[{\"r\":\"6\",\"s\":[{\"value\":[\"[\",\"\\\"Encounter\\\"\",\"]\"]}]}]},{\"value\":[\" \",\"E\"]}]}]},{\"value\":[\" \"]},{\"r\":\"12\",\"s\":[{\"value\":[\"where \"]},{\"r\":\"12\",\"s\":[{\"r\":\"10\",\"s\":[{\"r\":\"9\",\"s\":[{\"r\":\"8\",\"s\":[{\"value\":[\"E\"]}]},{\"value\":[\".\"]},{\"r\":\"9\",\"s\":[{\"value\":[\"period\"]}]}]},{\"value\":[\".\"]},{\"r\":\"10\",\"s\":[{\"value\":[\"start\"]}]}]},{\"r\":\"12\",\"value\":[\" \",\"during\",\" \"]},{\"r\":\"11\",\"s\":[{\"value\":[\"\\\"Measurement Period\\\"\"]}]}]}]}]}]}]}}],\"expression\":{\"localId\":\"14\",\"locator\":\"12:3-12:73\",\"type\":\"Exists\",\"operand\":{\"localId\":\"13\",\"locator\":\"12:10-12:73\",\"type\":\"Query\",\"source\":[{\"localId\":\"7\",\"locator\":\"12:10-12:24\",\"alias\":\"E\",\"expression\":{\"localId\":\"6\",\"locator\":\"12:10-12:22\",\"dataType\":\"{http://hl7.org/fhir}Encounter\",\"templateId\":\"http://hl7.org/fhir/StructureDefinition/Encounter\",\"type\":\"Retrieve\"}}],\"relationship\":[],\"where\":{\"localId\":\"12\",\"locator\":\"12:26-12:73\",\"type\":\"In\",\"operand\":[{\"name\":\"ToDateTime\",\"libraryName\":\"FHIRHelpers\",\"type\":\"FunctionRef\",\"operand\":[{\"localId\":\"10\",\"locator\":\"12:32-12:45\",\"path\":\"start\",\"type\":\"Property\",\"source\":{\"localId\":\"9\",\"locator\":\"12:32-12:39\",\"path\":\"period\",\"scope\":\"E\",\"type\":\"Property\"}}]},{\"localId\":\"11\",\"locator\":\"12:54-12:73\",\"name\":\"Measurement Period\",\"type\":\"ParameterRef\"}]}}}},{\"localId\":\"17\",\"locator\":\"14:1-15:7\",\"name\":\"denom\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"17\",\"s\":[{\"value\":[\"\",\"define \",\"\\\"denom\\\"\",\":\\n  \"]},{\"r\":\"16\",\"s\":[{\"value\":[\"\\\"ipp\\\"\"]}]}]}}],\"expression\":{\"localId\":\"16\",\"locator\":\"15:3-15:7\",\"name\":\"ipp\",\"type\":\"ExpressionRef\"}},{\"localId\":\"26\",\"locator\":\"17:1-18:52\",\"name\":\"num\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"26\",\"s\":[{\"value\":[\"\",\"define \",\"\\\"num\\\"\",\":\\n  \"]},{\"r\":\"25\",\"s\":[{\"value\":[\"exists \"]},{\"r\":\"24\",\"s\":[{\"s\":[{\"r\":\"19\",\"s\":[{\"r\":\"18\",\"s\":[{\"r\":\"18\",\"s\":[{\"value\":[\"[\",\"\\\"Encounter\\\"\",\"]\"]}]}]},{\"value\":[\" \",\"E\"]}]}]},{\"value\":[\" \"]},{\"r\":\"23\",\"s\":[{\"value\":[\"where \"]},{\"r\":\"23\",\"s\":[{\"r\":\"21\",\"s\":[{\"r\":\"20\",\"s\":[{\"value\":[\"E\"]}]},{\"value\":[\".\"]},{\"r\":\"21\",\"s\":[{\"value\":[\"status\"]}]}]},{\"value\":[\" \",\"~\",\" \"]},{\"r\":\"22\",\"s\":[{\"value\":[\"'finished'\"]}]}]}]}]}]}]}}],\"expression\":{\"localId\":\"25\",\"locator\":\"18:3-18:52\",\"type\":\"Exists\",\"operand\":{\"localId\":\"24\",\"locator\":\"18:10-18:52\",\"type\":\"Query\",\"source\":[{\"localId\":\"19\",\"locator\":\"18:10-18:24\",\"alias\":\"E\",\"expression\":{\"localId\":\"18\",\"locator\":\"18:10-18:22\",\"dataType\":\"{http://hl7.org/fhir}Encounter\",\"templateId\":\"http://hl7.org/fhir/StructureDefinition/Encounter\",\"type\":\"Retrieve\"}}],\"relationship\":[],\"where\":{\"localId\":\"23\",\"locator\":\"18:26-18:52\",\"type\":\"Equivalent\",\"operand\":[{\"name\":\"ToString\",\"libraryName\":\"FHIRHelpers\",\"type\":\"FunctionRef\",\"operand\":[{\"localId\":\"21\",\"locator\":\"18:32-18:39\",\"path\":\"status\",\"scope\":\"E\",\"type\":\"Property\"}]},{\"localId\":\"22\",\"locator\":\"18:43-18:52\",\"valueType\":\"{urn:hl7-org:elm-types:r1}String\",\"value\":\"finished\",\"type\":\"Literal\"}]}}}}]}},\"externalErrors\":[]}",
-  "groups": [
-    {
-      "id": "626be4370ca8110d3b22404b",
-      "scoring": "Proportion",
-      "populations": [
-        {
-          "id": "id1",
-          "name": "initialPopulation",
-          "definition": "ipp"
-        },
-        {
-          "id": "id2",
-          "name": "denominator",
-          "definition": "denom"
-        },
-        {
-          "id": "id3",
-          "name": "numerator",
-          "definition": "num"
-        }
-      ],
-      "measureGroupTypes": ["Outcome"]
-    }
-  ],
-  "createdAt": "2022-04-29T13:10:34.412Z",
-  "createdBy": "ashok.dongare@semanticbits.com",
-  "lastModifiedAt": "2022-05-05T16:47:15.461Z",
-  "lastModifiedBy": "ashok.dongare@semanticbits.com",
-  "measurementPeriodStart": "2023-01-01T05:00:00.000Z",
-  "measurementPeriodEnd": "2023-12-31T05:00:00.000Z",
-  "model": "QI-Core",
-  "measureMetaData": {}
+   "id":"62f66a8402b96d3a6ababefa",
+   "measureHumanReadableId":null,
+   "measureSetId":null,
+   "version":null,
+   "revisionNumber":null,
+   "state":null,
+   "cqlLibraryName":"SimpleFhirMeasureLib",
+   "measureName":"test 4495",
+   "active":true,
+   "cqlErrors":false,
+   "cql": "library SimpleFhirMeasureLib version '0.0.004'\n\nusing FHIR version '4.0.1'\n\ninclude FHIRHelpers version '4.0.001' called FHIRHelpers\n\nparameter \"Measurement Period\" Interval<DateTime>\n\ncontext Patient\n\ndefine \"ipp\":\n  exists [\"Encounter\"] E where E.period.start during \"Measurement Period\"\n\ndefine \"denom\":\n  \"ipp\"\n\ndefine \"num\":\n  exists [\"Encounter\"] E where E.status ~ 'finished'",
+   "elmJson": "{\"library\":{\"identifier\":{\"id\":\"SimpleFhirMeasureLib\",\"version\":\"0.0.004\"},\"schemaIdentifier\":{\"id\":\"urn:hl7-org:elm\",\"version\":\"r1\"},\"usings\":{\"def\":[{\"localIdentifier\":\"System\",\"uri\":\"urn:hl7-org:elm-types:r1\"},{\"localId\":\"1\",\"locator\":\"3:1-3:26\",\"localIdentifier\":\"FHIR\",\"uri\":\"http://hl7.org/fhir\",\"version\":\"4.0.1\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"1\",\"s\":[{\"value\":[\"\",\"using \"]},{\"s\":[{\"value\":[\"FHIR\"]}]},{\"value\":[\" version \",\"'4.0.1'\"]}]}}]}]},\"includes\":{\"def\":[{\"localId\":\"2\",\"locator\":\"5:1-5:56\",\"localIdentifier\":\"FHIRHelpers\",\"path\":\"FHIRHelpers\",\"version\":\"4.0.001\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"2\",\"s\":[{\"value\":[\"\",\"include \"]},{\"s\":[{\"value\":[\"FHIRHelpers\"]}]},{\"value\":[\" version \",\"'4.0.001'\",\" called \",\"FHIRHelpers\"]}]}}]}]},\"parameters\":{\"def\":[{\"localId\":\"5\",\"locator\":\"7:1-7:49\",\"name\":\"Measurement Period\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"5\",\"s\":[{\"value\":[\"\",\"parameter \",\"\\\"Measurement Period\\\"\",\" \"]},{\"r\":\"4\",\"s\":[{\"value\":[\"Interval<\"]},{\"r\":\"3\",\"s\":[{\"value\":[\"DateTime\"]}]},{\"value\":[\">\"]}]}]}}],\"parameterTypeSpecifier\":{\"localId\":\"4\",\"locator\":\"7:32-7:49\",\"type\":\"IntervalTypeSpecifier\",\"pointType\":{\"localId\":\"3\",\"locator\":\"7:41-7:48\",\"name\":\"{urn:hl7-org:elm-types:r1}DateTime\",\"type\":\"NamedTypeSpecifier\"}}}]},\"contexts\":{\"def\":[{\"locator\":\"9:1-9:15\",\"name\":\"Patient\"}]},\"statements\":{\"def\":[{\"locator\":\"9:1-9:15\",\"name\":\"Patient\",\"context\":\"Patient\",\"expression\":{\"type\":\"SingletonFrom\",\"operand\":{\"locator\":\"9:1-9:15\",\"dataType\":\"{http://hl7.org/fhir}Patient\",\"templateId\":\"http://hl7.org/fhir/StructureDefinition/Patient\",\"type\":\"Retrieve\"}}},{\"localId\":\"15\",\"locator\":\"11:1-12:73\",\"name\":\"ipp\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"15\",\"s\":[{\"value\":[\"\",\"define \",\"\\\"ipp\\\"\",\":\\n  \"]},{\"r\":\"14\",\"s\":[{\"value\":[\"exists \"]},{\"r\":\"13\",\"s\":[{\"s\":[{\"r\":\"7\",\"s\":[{\"r\":\"6\",\"s\":[{\"r\":\"6\",\"s\":[{\"value\":[\"[\",\"\\\"Encounter\\\"\",\"]\"]}]}]},{\"value\":[\" \",\"E\"]}]}]},{\"value\":[\" \"]},{\"r\":\"12\",\"s\":[{\"value\":[\"where \"]},{\"r\":\"12\",\"s\":[{\"r\":\"10\",\"s\":[{\"r\":\"9\",\"s\":[{\"r\":\"8\",\"s\":[{\"value\":[\"E\"]}]},{\"value\":[\".\"]},{\"r\":\"9\",\"s\":[{\"value\":[\"period\"]}]}]},{\"value\":[\".\"]},{\"r\":\"10\",\"s\":[{\"value\":[\"start\"]}]}]},{\"r\":\"12\",\"value\":[\" \",\"during\",\" \"]},{\"r\":\"11\",\"s\":[{\"value\":[\"\\\"Measurement Period\\\"\"]}]}]}]}]}]}]}}],\"expression\":{\"localId\":\"14\",\"locator\":\"12:3-12:73\",\"type\":\"Exists\",\"operand\":{\"localId\":\"13\",\"locator\":\"12:10-12:73\",\"type\":\"Query\",\"source\":[{\"localId\":\"7\",\"locator\":\"12:10-12:24\",\"alias\":\"E\",\"expression\":{\"localId\":\"6\",\"locator\":\"12:10-12:22\",\"dataType\":\"{http://hl7.org/fhir}Encounter\",\"templateId\":\"http://hl7.org/fhir/StructureDefinition/Encounter\",\"type\":\"Retrieve\"}}],\"relationship\":[],\"where\":{\"localId\":\"12\",\"locator\":\"12:26-12:73\",\"type\":\"In\",\"operand\":[{\"name\":\"ToDateTime\",\"libraryName\":\"FHIRHelpers\",\"type\":\"FunctionRef\",\"operand\":[{\"localId\":\"10\",\"locator\":\"12:32-12:45\",\"path\":\"start\",\"type\":\"Property\",\"source\":{\"localId\":\"9\",\"locator\":\"12:32-12:39\",\"path\":\"period\",\"scope\":\"E\",\"type\":\"Property\"}}]},{\"localId\":\"11\",\"locator\":\"12:54-12:73\",\"name\":\"Measurement Period\",\"type\":\"ParameterRef\"}]}}}},{\"localId\":\"17\",\"locator\":\"14:1-15:7\",\"name\":\"denom\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"17\",\"s\":[{\"value\":[\"\",\"define \",\"\\\"denom\\\"\",\":\\n  \"]},{\"r\":\"16\",\"s\":[{\"value\":[\"\\\"ipp\\\"\"]}]}]}}],\"expression\":{\"localId\":\"16\",\"locator\":\"15:3-15:7\",\"name\":\"ipp\",\"type\":\"ExpressionRef\"}},{\"localId\":\"26\",\"locator\":\"17:1-18:52\",\"name\":\"num\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"26\",\"s\":[{\"value\":[\"\",\"define \",\"\\\"num\\\"\",\":\\n  \"]},{\"r\":\"25\",\"s\":[{\"value\":[\"exists \"]},{\"r\":\"24\",\"s\":[{\"s\":[{\"r\":\"19\",\"s\":[{\"r\":\"18\",\"s\":[{\"r\":\"18\",\"s\":[{\"value\":[\"[\",\"\\\"Encounter\\\"\",\"]\"]}]}]},{\"value\":[\" \",\"E\"]}]}]},{\"value\":[\" \"]},{\"r\":\"23\",\"s\":[{\"value\":[\"where \"]},{\"r\":\"23\",\"s\":[{\"r\":\"21\",\"s\":[{\"r\":\"20\",\"s\":[{\"value\":[\"E\"]}]},{\"value\":[\".\"]},{\"r\":\"21\",\"s\":[{\"value\":[\"status\"]}]}]},{\"value\":[\" \",\"~\",\" \"]},{\"r\":\"22\",\"s\":[{\"value\":[\"'finished'\"]}]}]}]}]}]}]}}],\"expression\":{\"localId\":\"25\",\"locator\":\"18:3-18:52\",\"type\":\"Exists\",\"operand\":{\"localId\":\"24\",\"locator\":\"18:10-18:52\",\"type\":\"Query\",\"source\":[{\"localId\":\"19\",\"locator\":\"18:10-18:24\",\"alias\":\"E\",\"expression\":{\"localId\":\"18\",\"locator\":\"18:10-18:22\",\"dataType\":\"{http://hl7.org/fhir}Encounter\",\"templateId\":\"http://hl7.org/fhir/StructureDefinition/Encounter\",\"type\":\"Retrieve\"}}],\"relationship\":[],\"where\":{\"localId\":\"23\",\"locator\":\"18:26-18:52\",\"type\":\"Equivalent\",\"operand\":[{\"name\":\"ToString\",\"libraryName\":\"FHIRHelpers\",\"type\":\"FunctionRef\",\"operand\":[{\"localId\":\"21\",\"locator\":\"18:32-18:39\",\"path\":\"status\",\"scope\":\"E\",\"type\":\"Property\"}]},{\"localId\":\"22\",\"locator\":\"18:43-18:52\",\"valueType\":\"{urn:hl7-org:elm-types:r1}String\",\"value\":\"finished\",\"type\":\"Literal\"}]}}}}]}},\"externalErrors\":[]}",
+   "elmXml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<library xmlns=\"urn:hl7-org:elm:r1\" xmlns:t=\"urn:hl7-org:elm-types:r1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:fhir=\"http://hl7.org/fhir\" xmlns:qdm43=\"urn:healthit-gov:qdm:v4_3\" xmlns:qdm53=\"urn:healthit-gov:qdm:v5_3\" xmlns:a=\"urn:hl7-org:cql-annotations:r1\">\n   <annotation translatorOptions=\"EnableAnnotations,EnableLocators,EnableDetailedErrors,DisableListDemotion,DisableListPromotion\" xsi:type=\"a:CqlToElmInfo\"/>\n   <identifier/>\n   <schemaIdentifier id=\"urn:hl7-org:elm\" version=\"r1\"/>\n   <usings>\n      <def localIdentifier=\"System\" uri=\"urn:hl7-org:elm-types:r1\"/>\n   </usings>\n   <valueSets>\n      <def localId=\"1\" locator=\"1:1-1:97\" name=\"ONC Administrative Sex\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"1\">\n               <a:s>valueset &quot;ONC Administrative Sex&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"2\" locator=\"2:1-2:82\" name=\"Race\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"2\">\n               <a:s>valueset &quot;Race&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"3\" locator=\"3:1-3:87\" name=\"Ethnicity\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"3\">\n               <a:s>valueset &quot;Ethnicity&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"4\" locator=\"4:1-4:84\" name=\"Payer\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"4\">\n               <a:s>valueset &quot;Payer&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"5\" locator=\"5:1-5:87\" name=\"Female\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.2\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"5\">\n               <a:s>valueset &quot;Female&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.2'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"6\" locator=\"6:1-6:116\" name=\"Home Healthcare Services\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"6\">\n               <a:s>valueset &quot;Home Healthcare Services&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"7\" locator=\"7:1-7:128\" name=\"Hysterectomy with No Residual Cervix\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"7\">\n               <a:s>valueset &quot;Hysterectomy with No Residual Cervix&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"8\" locator=\"8:1-8:104\" name=\"Office Visit\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"8\">\n               <a:s>valueset &quot;Office Visit&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"9\" locator=\"9:1-9:100\" name=\"Pap Test\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"9\">\n               <a:s>valueset &quot;Pap Test&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"10\" locator=\"10:1-10:154\" name=\"Preventive Care Services - Established Office Visit, 18 and Up\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"10\">\n               <a:s>valueset &quot;Preventive Care Services - Established Office Visit, 18 and Up&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"11\" locator=\"11:1-11:148\" name=\"Preventive Care Services-Initial Office Visit, 18 and Up\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"11\">\n               <a:s>valueset &quot;Preventive Care Services-Initial Office Visit, 18 and Up&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n      <def localId=\"12\" locator=\"12:1-12:100\" name=\"HPV Test\" id=\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059\" accessLevel=\"Public\">\n         <annotation xsi:type=\"a:Annotation\">\n            <a:s r=\"12\">\n               <a:s>valueset &quot;HPV Test&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059'</a:s>\n            </a:s>\n         </annotation>\n      </def>\n   </valueSets>\n</library>\n",
+   "testCases":[
+      {
+         "id":"62fe4466848fd80e1dd3edd0",
+         "name":null,
+         "title":"test case title",
+         "series":"test case series",
+         "description":"test case description",
+         "createdAt":1660830822.381000000,
+         "createdBy":"cecilia.liu@semanticbits.com",
+         "lastModifiedAt":1660832513.936000000,
+         "lastModifiedBy":"cecilia.liu@semanticbits.com",
+         "json":"{\n  \"resourceType\": \"Bundle\",\n  \"id\": \"5\",\n  \"meta\": {\n    \"versionId\": \"1\",\n    \"lastUpdated\": \"2022-08-18T14:21:53.970+00:00\"\n  },\n  \"type\": \"collection\",\n  \"entry\": [ {\n    \"fullUrl\": \"http://local/Encounter\",\n    \"resource\": {\n      \"resourceType\": \"Encounter\",\n      \"meta\": {\n        \"versionId\": \"1\",\n        \"lastUpdated\": \"2021-10-13T03:34:10.160+00:00\",\n        \"source\": \"#nEcAkGd8PRwPP5fA\"\n      },\n      \"text\": {\n        \"status\": \"generated\",\n        \"div\": \"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\">Sep 9th 2021 for Asthma<a name=\\\"mm\\\"/></div>\"\n      },\n      \"status\": \"finished\",\n      \"class\": {\n        \"system\": \"2.16.840.1.113883.6.96\",\n        \"code\": \"185463005\",\n        \"display\": \"Visit out of hours (procedure)\"\n      },\n      \"type\": [ {\n        \"coding\": [ {\n          \"system\": \"2.16.840.1.113883.6.96\",\n          \"version\": \"2022-03\",\n          \"code\": \"185463005\",\n          \"display\": \"Visit out of hours (procedure)\"\n        } ]\n      } ],\n      \"subject\": {\n        \"reference\": \"Patient/1\"\n      },\n      \"participant\": [ {\n        \"individual\": {\n          \"reference\": \"Practitioner/30164\",\n          \"display\": \"Dr John Doe\"\n        }\n      } ],\n      \"period\": {\n        \"start\": \"2020-12-31T03:34:10.054Z\"\n      }\n    }\n  }, {\n    \"fullUrl\": \"http://local/Patient\",\n    \"resource\": {\n      \"resourceType\": \"Patient\",\n      \"text\": {\n        \"status\": \"generated\",\n        \"div\": \"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\">Lizzy Health</div>\"\n      },\n      \"identifier\": [ {\n        \"system\": \"http://clinfhir.com/fhir/NamingSystem/identifier\",\n        \"value\": \"20181011LizzyHealth\"\n      } ],\n      \"name\": [ {\n        \"use\": \"official\",\n        \"text\": \"Lizzy Health\",\n        \"family\": \"Health\",\n        \"given\": [ \"Lizzy\" ]\n      } ],\n      \"gender\": \"female\",\n      \"birthDate\": \"2000-10-11\"\n    }\n  } ]\n}",
+         "hapiOperationOutcome":null,
+         "groupPopulations":[
+            {
+               "groupId":"62f66b2e02b96d3a6ababefb",
+               "scoring":"Ratio",
+               "populationValues":[
+                  {
+                     "name":"initialPopulation",
+                     "expected":false,
+                     "actual":false
+                  },
+                  {
+                     "name":"initialPopulation",
+                     "expected":false,
+                     "actual":false
+                  },
+                  {
+                     "name":"denominator",
+                     "expected":false,
+                     "actual":false
+                  },
+                  {
+                     "name":"denominatorExclusion",
+                     "expected":false,
+                     "actual":false
+                  },
+                  {
+                     "name":"numerator",
+                     "expected":false,
+                     "actual":false
+                  },
+                  {
+                     "name":"numeratorExclusion",
+                     "expected":false,
+                     "actual":false
+                  }
+               ]
+            }
+         ]
+      }
+   ],
+   "groups":[
+      {
+         "id":"62f66b2e02b96d3a6ababefb",
+         "scoring":"Ratio",
+         "populations":[
+            {
+               "id":"12b60c2c-e9ee-4bac-bba3-dc2df691f3ac",
+               "name":"initialPopulation",
+               "definition":"SDE Ethnicity",
+               "associationType":"Denominator"
+            },
+            {
+               "id":"1",
+               "name":"initialPopulation",
+               "definition":"SDE Ethnicity",
+               "associationType":"Numerator"
+            },
+            {
+               "id":"dd775fb3-19ff-44c0-9083-7ad4bfa39b8c",
+               "name":"denominator",
+               "definition":"Pap Test Within 3 Years",
+               "associationType":null
+            },
+            {
+               "id":"87d0d6c9-bc96-43aa-a151-b520409a10b8",
+               "name":"denominatorExclusion",
+               "definition":"Pap Test with Results",
+               "associationType":null
+            },
+            {
+               "id":"deb34843-05e3-4b29-aa63-1b0a4439eeac",
+               "name":"numerator",
+               "definition":"Pap Test with Results",
+               "associationType":null
+            },
+            {
+               "id":"7790db4c-0f7f-48dc-8dc2-871b42ab3abf",
+               "name":"numeratorExclusion",
+               "definition":"Pap Test with Results",
+               "associationType":null
+            }
+         ],
+         "measureGroupTypes":[
+            "Patient Reported Outcome",
+            "Outcome"
+         ],
+         "measureObservations":null,
+         "groupDescription":"test 4495 group 1",
+         "improvementNotation":"",
+         "rateAggregation":"",         
+         "scoringUnit":{
+            "label":"kg kilogram",
+            "value":{
+               "code":"kg",
+               "name":"kilogram",
+               "guidance":null
+            }
+         },
+         "stratifications":[
+            
+         ],
+         "populationBasis":"Account"
+      },
+      {
+         "id":"62fb788bfb3c765290171e75",
+         "scoring":"Ratio",
+         "populations":[
+            {
+               "id":"545d860e-f9af-4efc-8587-fc3018673082",
+               "name":"initialPopulation",
+               "definition":"SDE Payer",
+               "associationType":"Denominator"
+            },
+            {
+               "id":"ba763149-00b8-49ed-9159-594e30e02c70",
+               "name":"denominator",
+               "definition":"Initial Population",
+               "associationType":null
+            },
+            {
+               "id":"a9036584-04d6-4e61-964f-423aad9120d9",
+               "name":"denominatorExclusion",
+               "definition":"Denominator",
+               "associationType":null
+            },
+            {
+               "id":"5e898288-88a4-4ed6-970b-c5848a812851",
+               "name":"numerator",
+               "definition":"Absence of Cervix",
+               "associationType":null
+            },
+            {
+               "id":"c38e28f7-632f-4f4f-9e94-c2dda446e5ed",
+               "name":"numeratorExclusion",
+               "definition":"Pap Test with Results",
+               "associationType":null
+            }
+         ],
+         "measureObservations":null,
+         "groupDescription":"group2",
+         "improvementNotation":"",
+         "rateAggregation":"",
+         "measureGroupTypes":[
+            "Outcome"
+         ],
+         "scoringUnit":{
+            "label":"Number",
+            "value":{
+               "code":"number"
+            }
+         },
+         "stratifications":[
+            
+         ],
+         "populationBasis":"Boolean"
+      }
+   ],
+   "createdAt":1660316292.981000000,
+   "createdBy":"cecilia.liu@semanticbits.com",
+   "lastModifiedAt":1660837753.247000000,
+   "lastModifiedBy":"cecilia.liu@semanticbits.com",
+   "measurementPeriodStart": "2023-01-01T05:00:00.000Z",
+   "measurementPeriodEnd": "2023-12-31T05:00:00.000Z",
+   "model":"QI-Core",
+   "measureMetaData":{
+      "steward":null,
+      "description":null,
+      "copyright":null,
+      "disclaimer":null,
+      "rationale":null,
+      "author":null,
+      "guidance":null
+   }
 }

--- a/src/test/resources/measures/SimpleFhirMeasureLib/madie_ratio_measure.json
+++ b/src/test/resources/measures/SimpleFhirMeasureLib/madie_ratio_measure.json
@@ -12,13 +12,15 @@
         {
           "id": "id1",
           "name": "initialPopulation",
-          "definition": "ipp"
+          "definition": "ipp",
+          "associationType":"Denominator"          
         },
         {
           "id": "id4",
           "name": "initialPopulation",
-          "definition": "ipp2"
-        },
+          "definition": "ipp2",
+          "associationType":"Numerator"
+       	},
         {
           "id": "id2",
           "name": "denominator",
@@ -30,7 +32,23 @@
           "definition": "num"
         }
       ],
-      "measureGroupTypes": ["Outcome"]
+      "measureGroupTypes": ["Outcome"],
+         "measureObservations":null,
+         "groupDescription":"test 4495 group 1",
+         "improvementNotation":"",
+         "rateAggregation":"",         
+         "scoringUnit":{
+            "label":"kg kilogram",
+            "value":{
+               "code":"kg",
+               "name":"kilogram",
+               "guidance":null
+            }
+         },
+         "stratifications":[
+            
+         ],
+         "populationBasis":"Account"
     }
   ],
   "createdAt": "2022-04-29T13:10:34.412Z",


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-4527](https://jira.cms.gov/browse/MAT-4527)
(Optional) Related Tickets:

### Summary
Added the capability to ingest the population associations for a Ratio measure.  This is complicated by the fact that the data design for our Madie.measure is different than FHIR.measure so we have to pull the association from IP and apply it to Denom or Numer

### All Submissions
* [x] This PR has the JIRA linked.
* [X] Required tests are included.
* [X] No extemporaneous files are included (i.e Complied files or testing results).
* [X] This PR is merging into the **correct branch**.
* [X] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [X] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
