### PR TITLE
[MAT-5508] Remove Typecasting for Use Context in Liquid Templates

### DIFF
--- a/src/main/resources/templates/Library.liquid
+++ b/src/main/resources/templates/Library.liquid
@@ -187,8 +187,8 @@
                         {% for useContext in Library.useContext %}
                             <tr>
                                 <td>{{useContext.code.code}}</td>
-                                <td>{{(useContext.value as CodeableConcept).coding.first().code}}</td>
-                                <td>{{(useContext.value as CodeableConcept).coding.first().display.escape('html')}}</td>
+                                <td>{{useContext.value.coding.first().code}}</td>
+                                <td>{{useContext.value.coding.first().display.escape('html')}}</td>
                             </tr>
                         {% endfor %}
                     </table>

--- a/src/main/resources/templates/Measure.liquid
+++ b/src/main/resources/templates/Measure.liquid
@@ -485,7 +485,7 @@
                         {% for useContext in Measure.useContext %}
                             <tr>
                                 <td>{{useContext.code.code}}</td>
-                                <td>{{(useContext.valueCodeableConcept).text}}</td>
+                                <td>{{useContext.value.coding.first().code}}</td>
                             </tr>
                         {% endfor %}
                     </table>


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-5508](https://jira.cms.gov/browse/MAT-5508)
(Optional) Related Tickets:

### Summary
- Remove the CodeableConcept typecasting for Use Context. The FHIRPathEngine is able to recognize the obj without typecasting, and it breaks with it in place.
- Use 'Use Context' paths from Library template to correct the 'code' display.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
