### PR TITLE
[MAT-5541] Remove leading slash from folder names

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/services/ExportService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/ExportService.java
@@ -36,8 +36,8 @@ public class ExportService {
   private final HumanReadableService humanReadableService;
 
   private static final String TEXT_CQL = "text/cql";
-  private static final String CQL_DIRECTORY = "/cql/";
-  private static final String RESOURCES_DIRECTORY = "/resources/";
+  private static final String CQL_DIRECTORY = "cql/";
+  private static final String RESOURCES_DIRECTORY = "resources/";
 
   public void createExport(
       Measure madieMeasure, OutputStream outputStream, Principal principal, String accessToken) {

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/ExportServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/ExportServiceTest.java
@@ -92,12 +92,12 @@ class ExportServiceTest implements ResourceFileUtil {
         List.of(
             "ExportTest-v1.0.000-FHIR.json",
             "ExportTest-v1.0.000-FHIR.xml",
-            "/cql/ExportTest-0.0.000.cql",
-            "/cql/FHIRHelpers-4.1.000.cql",
-            "/resources/ExportTest-0.0.000.json",
-            "/resources/ExportTest-0.0.000.xml",
-            "/resources/FHIRHelpers-4.1.000.json",
-            "/resources/FHIRHelpers-4.1.000.xml",
+            "cql/ExportTest-0.0.000.cql",
+            "cql/FHIRHelpers-4.1.000.cql",
+            "resources/ExportTest-0.0.000.json",
+            "resources/ExportTest-0.0.000.xml",
+            "resources/FHIRHelpers-4.1.000.json",
+            "resources/FHIRHelpers-4.1.000.xml",
             "ExportTest-v1.0.000-FHIR.html");
 
     ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(out.toByteArray()));


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-5541](https://jira.cms.gov/browse/MAT-5541)
(Optional) Related Tickets:

### Summary
Windows 10/11 is failing to parse the leading '/' in the folder name, resulting in the folders disappearing and failing to extract when using the built-in Windows zip tool.

7-zip sees the leading slash as an empty directly, and does manage to extract the folders as expected.

After removing the slash, Win 10/11 & macs are able to extract the zip contents as expected.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
