### PR TITLE
[MAT-6031] Set fullUrl on MeasureReport Bundle Entry

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/services/TestCaseBundleService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/TestCaseBundleService.java
@@ -72,6 +72,11 @@ public class TestCaseBundleService {
       String fileName = ExportFileNamesUtil.getTestCaseExportFileName(measure, testCase);
       var measureReport = buildMeasureReport(testCase, measure, bundle);
       var bundleEntryComponent = FhirResourceHelpers.getBundleEntryComponent(measureReport);
+      bundleEntryComponent.setFullUrl(
+          "https://madie.cms.gov/MeasureReport/"
+              + measure.getId()
+              + "/"
+              + testCase.getPatientId().toString());
       bundle.getEntry().add(bundleEntryComponent);
       testCaseBundle.put(fileName, bundle);
     }

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/TestCaseBundleServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/TestCaseBundleServiceTest.java
@@ -73,6 +73,9 @@ class TestCaseBundleServiceTest implements ResourceFileUtil {
         exportMap.get(
             "285d114d-9c36-4d66-b0a0-06f395bbf23d/title-v0.0.000-test case series-test case title");
     assertEquals(5, bundle.getEntry().size());
+    assertEquals("https://madie.cms.gov/MeasureReport/" + madieMeasure.getId()
+                    + "/285d114d-9c36-4d66-b0a0-06f395bbf23d",
+            bundle.getEntry().get(4).getFullUrl());
     MeasureReport measureReport = (MeasureReport) bundle.getEntry().get(4).getResource();
     assertEquals("MeasureReport", measureReport.getResourceType().toString());
     assertEquals(


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-6031](https://jira.cms.gov/browse/MAT-6031)
(Optional) Related Tickets:

### Summary

Set the `fullUrl` element on the Bundle entry containing the MeasureReport. I guess at the contents, which is made up of the madie prod url, measure ID, and the patient ID.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
