### PR TITLE
MAT-6387 optional populations are not added to measure resource bundl…

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
@@ -287,9 +287,7 @@ public class MeasureTranslatorService {
 
   private List<MeasureGroupPopulationComponent> buildPopulations(Group madieGroup) {
     return madieGroup.getPopulations().stream()
-        .filter(
-            population ->
-                population.getDefinition() != null && !population.getDefinition().isEmpty())
+        .filter(population -> StringUtils.isNotBlank(population.getDefinition()))
         .map(
             population -> {
               String populationCode = population.getName().toCode();

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
@@ -287,6 +287,7 @@ public class MeasureTranslatorService {
 
   private List<MeasureGroupPopulationComponent> buildPopulations(Group madieGroup) {
     return madieGroup.getPopulations().stream()
+        .filter(population -> population.getDefinition() != null && !population.getDefinition().isEmpty())
         .map(
             population -> {
               String populationCode = population.getName().toCode();

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
@@ -287,7 +287,9 @@ public class MeasureTranslatorService {
 
   private List<MeasureGroupPopulationComponent> buildPopulations(Group madieGroup) {
     return madieGroup.getPopulations().stream()
-        .filter(population -> population.getDefinition() != null && !population.getDefinition().isEmpty())
+        .filter(
+            population ->
+                population.getDefinition() != null && !population.getDefinition().isEmpty())
         .map(
             population -> {
               String populationCode = population.getName().toCode();

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorServiceTest.java
@@ -14,10 +14,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.cms.madie.madiefhirservice.constants.UriConstants;
@@ -205,6 +202,8 @@ public class MeasureTranslatorServiceTest implements ResourceFileUtil {
           is("http://terminology.hl7.org/CodeSystem/measure-type"));
     }
 
+    // numeratorExclusion is not assigned (null), so it is not added to the measure resource.
+    assertNotEquals(measure.getGroup().get(0).getPopulation().size(), madieMeasure.getGroups().get(0).getPopulations().size());
     MeasureGroupPopulationComponent groupComponent =
         measure.getGroup().get(0).getPopulation().get(0);
     assertThat(groupComponent.getCriteria().getLanguage(), is(equalTo("text/cql-identifier")));

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorServiceTest.java
@@ -203,7 +203,9 @@ public class MeasureTranslatorServiceTest implements ResourceFileUtil {
     }
 
     // numeratorExclusion is not assigned (null), so it is not added to the measure resource.
-    assertNotEquals(measure.getGroup().get(0).getPopulation().size(), madieMeasure.getGroups().get(0).getPopulations().size());
+    assertNotEquals(
+        measure.getGroup().get(0).getPopulation().size(),
+        madieMeasure.getGroups().get(0).getPopulations().size());
     MeasureGroupPopulationComponent groupComponent =
         measure.getGroup().get(0).getPopulation().get(0);
     assertThat(groupComponent.getCriteria().getLanguage(), is(equalTo("text/cql-identifier")));

--- a/src/test/resources/measures/SimpleFhirMeasureLib/madie_measure.json
+++ b/src/test/resources/measures/SimpleFhirMeasureLib/madie_measure.json
@@ -159,7 +159,7 @@
             {
                "id":"7790db4c-0f7f-48dc-8dc2-871b42ab3abf",
                "name":"numeratorExclusion",
-               "definition":"Pap Test with Results",
+               "definition": null,
                "associationType":null
             }
          ],


### PR DESCRIPTION
…e if not selected by user

## MADiE FHIR SERVICE

Jira Ticket: [MAT-6387](https://jira.cms.gov/browse/MAT-6387)
(Optional) Related Tickets:

### Summary

1. If user doesn't select an optional population, then it is not added to measure bundle.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
