### PR TITLE
[MAT-7156, MAT-7162] Verify partial HAPI objects have a date type value

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/services/TestCaseDateShifterService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/TestCaseDateShifterService.java
@@ -74,7 +74,11 @@ public class TestCaseDateShifterService {
           if (value.isPrimitive()) {
             if (value.isDateTime()) {
               BaseDateTimeType dateType = (BaseDateTimeType) value;
-              dateType.add(1, shifted);
+              // HAPI will build partial objects when given partial data, like only an extension.
+              // Verify the target date value is non-null.
+              if(dateType.getValue() != null) {
+                dateType.add(1, shifted);
+              }
             }
           } else {
             shiftDates(value, shifted);


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-7156](https://jira.cms.gov/browse/MAT-7156)
(Optional) Related Tickets:

### Summary

HAPI will build out DateTime objects with `null` values. For example, a `Procedure.Performed` element with only an extension containing a Code will return true for `isDateTime()`, but have `null` DateTime value.


### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
