### PR TITLE
MAT-7570: Limit the date shift year result range to [1900, 9999]

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/services/TestCaseDateShifterService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/TestCaseDateShifterService.java
@@ -85,8 +85,8 @@ public class TestCaseDateShifterService {
                 ZonedDateTime shifted = date.atZone(ZoneId.of("UTC")).plusYears(shiftBy);
                 if (shifted.getYear() > 9999) {
                   dateType.setValue(DateUtils.setYears(dateType.getValue(), 9999));
-                } else if (shifted.getYear() < 0) {
-                  dateType.setValue(DateUtils.setYears(dateType.getValue(), 1));
+                } else if (shifted.getYear() < 1900) {
+                  dateType.setValue(DateUtils.setYears(dateType.getValue(), 1900));
                 } else {
                   dateType.add(1, shiftBy);
                 }

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/TestCaseDateShifterService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/TestCaseDateShifterService.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DateUtils;
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.BaseDateTimeType;
 import org.hl7.fhir.r4.model.Bundle;
@@ -16,6 +17,9 @@ import org.hl7.fhir.r4.model.Property;
 import org.springframework.stereotype.Service;
 
 import java.lang.reflect.Field;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 @Slf4j
@@ -25,18 +29,18 @@ public class TestCaseDateShifterService {
 
   private FhirContext fhirContext;
 
-  public TestCase shiftDates(TestCase testCase, int shifted) {
+  public TestCase shiftDates(TestCase testCase, int shiftBy) {
     if (testCase == null) {
       return null;
     }
-    List<TestCase> shiftedTestCases = shiftDates(List.of(testCase), shifted);
+    List<TestCase> shiftedTestCases = shiftDates(List.of(testCase), shiftBy);
     if (CollectionUtils.isNotEmpty(shiftedTestCases) && shiftedTestCases.size() == 1) {
       return shiftedTestCases.get(0);
     }
     return null;
   }
 
-  public List<TestCase> shiftDates(List<TestCase> testCases, int shifted) {
+  public List<TestCase> shiftDates(List<TestCase> testCases, int shiftBy) {
     if (CollectionUtils.isEmpty(testCases)) {
       return Collections.emptyList();
     }
@@ -51,7 +55,7 @@ public class TestCaseDateShifterService {
         // convert test case json to bundle
         Bundle bundle = parser.parseResource(Bundle.class, testCase.getJson());
         // update the test case dates
-        bundle.getEntry().forEach(entry -> shiftDates(entry.getResource(), shifted));
+        bundle.getEntry().forEach(entry -> shiftDates(entry.getResource(), shiftBy));
         // convert the updated bundle to string and assign back to test case.
         String json = parser.encodeResourceToString(bundle);
         testCase.setJson(json);
@@ -63,7 +67,7 @@ public class TestCaseDateShifterService {
     return shiftedTestCases;
   }
 
-  void shiftDates(Base baseResource, int shifted) {
+  void shiftDates(Base baseResource, int shiftBy) {
     List<Field> fields = new LinkedList<>();
     getAllFields(fields, baseResource.getClass());
     for (Field field : fields) {
@@ -77,11 +81,19 @@ public class TestCaseDateShifterService {
               // HAPI will build partial objects when given partial data, like only an extension.
               // Verify the target date value is non-null.
               if (dateType.getValue() != null) {
-                dateType.add(1, shifted);
+                Instant date = dateType.getValue().toInstant();
+                ZonedDateTime shifted = date.atZone(ZoneId.of("UTC")).plusYears(shiftBy);
+                if (shifted.getYear() > 9999) {
+                  dateType.setValue(DateUtils.setYears(dateType.getValue(), 9999));
+                } else if (shifted.getYear() < 0) {
+                  dateType.setValue(DateUtils.setYears(dateType.getValue(), 1));
+                } else {
+                  dateType.add(1, shiftBy);
+                }
               }
             }
           } else {
-            shiftDates(value, shifted);
+            shiftDates(value, shiftBy);
           }
         }
       }

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/TestCaseDateShifterServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/TestCaseDateShifterServiceTest.java
@@ -278,6 +278,6 @@ public class TestCaseDateShifterServiceTest implements ResourceFileUtil {
     Date originalBirthDate = (Date) patient.getBirthDate().clone();
     int shiftBy = -1000000; // years
     testCaseDateShifterService.shiftDates(patient, shiftBy);
-    assertEquals(DateUtils.setYears(originalBirthDate, 1), patient.getBirthDate());
+    assertEquals(DateUtils.setYears(originalBirthDate, 1900), patient.getBirthDate());
   }
 }

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/TestCaseDateShifterServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/TestCaseDateShifterServiceTest.java
@@ -262,4 +262,22 @@ public class TestCaseDateShifterServiceTest implements ResourceFileUtil {
     testCaseDateShifterService.shiftDates(procedure, 1);
     assertTrue(copy.getPerformed().equalsDeep(procedure.getPerformed()));
   }
+
+  @Test
+  void limitsUpperYearRangeTo9999() {
+    Patient patient = (Patient) ResourceUtils.getResource(testCaseBundle, "Patient");
+    Date originalBirthDate = (Date) patient.getBirthDate().clone();
+    int shiftBy = 1000000; // years
+    testCaseDateShifterService.shiftDates(patient, shiftBy);
+    assertEquals(DateUtils.setYears(originalBirthDate, 9999), patient.getBirthDate());
+  }
+
+  @Test
+  void limitsLowerYearRangeTo0() {
+    Patient patient = (Patient) ResourceUtils.getResource(testCaseBundle, "Patient");
+    Date originalBirthDate = (Date) patient.getBirthDate().clone();
+    int shiftBy = -1000000; // years
+    testCaseDateShifterService.shiftDates(patient, shiftBy);
+    assertEquals(DateUtils.setYears(originalBirthDate, 1), patient.getBirthDate());
+  }
 }


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-7570](https://jira.cms.gov/browse/MAT-7570)
(Optional) Related Tickets:

### Summary

Limit the Date Shift year result range to [1900, 9999].

Also remembered to commit the formatter updates 👍  

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
