### PR TITLE
[MAT-7966] Use DataRequirementsProcessor to build Data Requirements for Included Libraries

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/services/ExportService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/ExportService.java
@@ -31,8 +31,7 @@ public class ExportService {
 
     PackagingUtility utility;
     try {
-      // TODO.. this method is already tied to FHIR.  so.. just hardcoding for now
-      utility = PackagingUtilityFactory.getInstance("QI-Core v4.1.1");
+      utility = PackagingUtilityFactory.getInstance(madieMeasure.getModel());
     } catch (InstantiationException
         | IllegalAccessException
         | IllegalArgumentException

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/LibraryService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/LibraryService.java
@@ -2,6 +2,7 @@ package gov.cms.madie.madiefhirservice.services;
 
 import gov.cms.madie.madiefhirservice.cql.LibraryCqlVisitor;
 import gov.cms.madie.madiefhirservice.cql.LibraryCqlVisitorFactory;
+import gov.cms.madie.madiefhirservice.dto.CqlLibraryDetails;
 import gov.cms.madie.madiefhirservice.exceptions.LibraryAttachmentNotFoundException;
 import gov.cms.madie.madiefhirservice.exceptions.MissingCqlException;
 import gov.cms.madie.madiefhirservice.utils.BundleUtil;
@@ -10,12 +11,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_40_50;
+import org.hl7.fhir.convertors.conv40_50.VersionConvertor_40_50;
 import org.hl7.fhir.r4.model.Attachment;
+import org.hl7.fhir.r4.model.DataRequirement;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Narrative;
 import org.hl7.fhir.r4.model.Narrative.NarrativeStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -27,6 +32,7 @@ public class LibraryService {
   private final LibraryTranslatorService libraryTranslatorService;
   private final LibraryCqlVisitorFactory libCqlVisitorFactory;
   private final HumanReadableService humanReadableService;
+  private final ElmTranslatorClient elmTranslatorClient;
 
   public String getLibraryCql(String name, String version, final String accessToken) {
     CqlLibrary library = cqlLibraryService.getLibrary(name, version, accessToken);
@@ -36,19 +42,33 @@ public class LibraryService {
     return cqlLibraryService.getLibrary(name, version, accessToken).getCql();
   }
 
-  private Attachment findCqlAttachment(Library library) {
-    return library.getContent().stream()
-        .filter(a -> a.getContentType().equals("text/cql"))
-        .findFirst()
-        .orElseThrow(() -> new LibraryAttachmentNotFoundException(library, "text/cql"));
-  }
-
-  public Library cqlLibraryToFhirLibrary(CqlLibrary cqlLibrary, final String bundleType) {
+  public Library cqlLibraryToFhirLibrary(
+      CqlLibrary cqlLibrary, final String bundleType, String accessToken) {
+    // Use the DataRequirementsProcessor to typecast Profile types
+    // (e.g. "QICore Simple Observation") to FHIR types (e.g. "Observation").
+    List<DataRequirement> fhirTypedDataRequirements =
+        retrieveLibraryDataRequirements(
+            CqlLibraryDetails.builder()
+                .libraryName(cqlLibrary.getCqlLibraryName())
+                .cql(cqlLibrary.getCql())
+                .build(),
+            accessToken);
     Library library = libraryTranslatorService.convertToFhirLibrary(cqlLibrary);
+    library.setDataRequirement(fhirTypedDataRequirements);
     if (BundleUtil.MEASURE_BUNDLE_TYPE_EXPORT.equals(bundleType)) {
       library.setText(createLibraryNarrativeText(library));
     }
     return library;
+  }
+
+  private List<DataRequirement> retrieveLibraryDataRequirements(
+      CqlLibraryDetails cqlLibraryDetails, String accessToken) {
+    org.hl7.fhir.r5.model.Library r5moduleDefinition =
+        elmTranslatorClient.getModuleDefinitionLibrary(cqlLibraryDetails, false, accessToken);
+    var versionConvertor_40_50 = new VersionConvertor_40_50(new BaseAdvisor_40_50());
+    org.hl7.fhir.r4.model.Library r4moduleDefinitionLibrary =
+        (org.hl7.fhir.r4.model.Library) versionConvertor_40_50.convertResource(r5moduleDefinition);
+    return r4moduleDefinitionLibrary.getDataRequirement();
   }
 
   public void getIncludedLibraries(
@@ -63,16 +83,17 @@ public class LibraryService {
 
     LibraryCqlVisitor visitor = libCqlVisitorFactory.visit(cql);
     for (Pair<String, String> libraryNameValuePair : visitor.getIncludedLibraries()) {
-      CqlLibrary cqlLibrary =
-          cqlLibraryService.getLibrary(
-              libraryNameValuePair.getLeft(), libraryNameValuePair.getRight(), accessToken);
-      Library library = cqlLibraryToFhirLibrary(cqlLibrary, bundleType);
-      String key = library.getName() + library.getVersion();
+      String key = libraryNameValuePair.getLeft() + libraryNameValuePair.getRight();
       if (!libraryMap.containsKey(key)) {
+        CqlLibrary cqlLibrary =
+            cqlLibraryService.getLibrary(
+                libraryNameValuePair.getLeft(), libraryNameValuePair.getRight(), accessToken);
+        Library library = cqlLibraryToFhirLibrary(cqlLibrary, bundleType, accessToken);
         libraryMap.put(key, library);
+
+        Attachment attachment = findCqlAttachment(library);
+        getIncludedLibraries(new String(attachment.getData()), libraryMap, bundleType, accessToken);
       }
-      Attachment attachment = findCqlAttachment(library);
-      getIncludedLibraries(new String(attachment.getData()), libraryMap, bundleType, accessToken);
     }
   }
 
@@ -81,5 +102,12 @@ public class LibraryService {
     narrative.setStatus(NarrativeStatus.EXTENSIONS);
     narrative.setDivAsString(humanReadableService.generateLibraryHumanReadable(library));
     return narrative;
+  }
+
+  private Attachment findCqlAttachment(Library library) {
+    return library.getContent().stream()
+        .filter(a -> a.getContentType().equals("text/cql"))
+        .findFirst()
+        .orElseThrow(() -> new LibraryAttachmentNotFoundException(library, "text/cql"));
   }
 }

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/LibraryTranslatorService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/LibraryTranslatorService.java
@@ -56,15 +56,13 @@ public class LibraryTranslatorService {
         cqlLibrary.getPublisher() != null && StringUtils.isNotBlank(cqlLibrary.getPublisher())
             ? cqlLibrary.getPublisher()
             : UNKNOWN_VALUE);
-    library.setDescription(StringUtils.defaultString(cqlLibrary.getDescription(), UNKNOWN_VALUE));
+    library.setDescription(Objects.toString(cqlLibrary.getDescription(), UNKNOWN_VALUE));
     library.setExperimental(cqlLibrary.isExperimental());
     library.setContent(
         createContent(cqlLibrary.getCql(), cqlLibrary.getElmJson(), cqlLibrary.getElmXml()));
     library.setType(createType(UriConstants.LIBRARY_SYSTEM_TYPE_URI, SYSTEM_CODE));
     library.setUrl(
         FhirResourceHelpers.buildResourceFullUrl("Library", cqlLibrary.getCqlLibraryName()));
-    library.setDataRequirement(distinctDataRequirements(visitor.getDataRequirements()));
-
     library.getExtension().addAll(visitor.getDrcExtensions());
     library.setRelatedArtifact(distinctArtifacts(visitor.getRelatedArtifacts()));
     library.setMeta(createLibraryMeta());

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/LibraryServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/LibraryServiceTest.java
@@ -1,6 +1,7 @@
 package gov.cms.madie.madiefhirservice.services;
 
 import gov.cms.madie.madiefhirservice.cql.LibraryCqlVisitorFactory;
+import gov.cms.madie.madiefhirservice.dto.CqlLibraryDetails;
 import gov.cms.madie.madiefhirservice.exceptions.*;
 import gov.cms.madie.madiefhirservice.utils.BundleUtil;
 import gov.cms.madie.madiefhirservice.utils.LibraryHelper;
@@ -28,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
@@ -41,6 +43,7 @@ class LibraryServiceTest implements LibraryHelper, ResourceFileUtil {
   @Mock private LibraryTranslatorService libraryTranslatorService;
   @Mock private LibraryCqlVisitorFactory libCqlVisitorFactory;
   @Mock private HumanReadableService humanReadableService;
+  @Mock private ElmTranslatorClient elmTranslatorClient;
   private Library fhirHelpersLibrary;
 
   Bundle bundle = new Bundle();
@@ -133,12 +136,15 @@ class LibraryServiceTest implements LibraryHelper, ResourceFileUtil {
     when(cqlLibraryService.getLibrary(anyString(), anyString(), anyString()))
         .thenReturn(cqlLibrary);
     when(libraryTranslatorService.convertToFhirLibrary(any(CqlLibrary.class))).thenReturn(library);
+    when(elmTranslatorClient.getModuleDefinitionLibrary(
+            any(CqlLibraryDetails.class), anyBoolean(), anyString()))
+        .thenReturn(new org.hl7.fhir.r5.model.Library());
 
     Map<String, Library> includedLibraryMap = new HashMap<>();
     libraryService.getIncludedLibraries(
         mainLibrary, includedLibraryMap, BundleUtil.MEASURE_BUNDLE_TYPE_EXPORT, "TOKEN");
     assertThat(includedLibraryMap.size(), is(equalTo(1)));
-    assertNotNull(includedLibraryMap.get("IncludedLibrary0.1.0"));
+    assertNotNull(includedLibraryMap.get("IncludedLibrary0.1.000"));
   }
 
   @Test

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/LibraryTranslatorServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/LibraryTranslatorServiceTest.java
@@ -51,7 +51,6 @@ public class LibraryTranslatorServiceTest implements ResourceFileUtil, LibraryHe
     Library library = libraryTranslatorService.convertToFhirLibrary(cqlLibrary);
     assertEquals(library.getName(), cqlLibrary.getCqlLibraryName());
     assertEquals(library.getVersion(), cqlLibrary.getVersion().toString());
-    assertEquals(library.getDataRequirement().size(), visitor.getDataRequirements().size());
     assertThat(library.getTitle(), is(equalTo(cqlLibrary.getCqlLibraryName())));
     assertThat(library.getPublisher(), is(equalTo(cqlLibrary.getPublisher())));
     Identifier identifier = new Identifier();


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-7966](https://jira.cms.gov/browse/MAT-7966)
(Optional) Related Tickets:

### Summary

Use Data Requirements Processor (DRP) to build Data Requirements for Included Libraries instead of creating them manually from the ANTLR parse of the CQL. 

With the inclusion of US-Core and QI-Core Profiles, we need to use the DRP to properly typecast Profile based Types to their FHIR relative. The Parser is limited to the CQL text and will build Data Requirements such as "QICore Simple Observation" (instead of "Observation"), which will cause the downstream FHIR converter (R4 to R5) to error out.

Note: We have to perform the R4 to R5 conversion because we're using the R5 Liquid Engine to generate the Human Readable. The R4 Liquid Engine doesn't have the necessary support to process the provided Liquid templates.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
