### PR TITLE
MAT-7961: Trim the eCQM Abbr Title when used in an export filename.

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/utils/ExportFileNamesUtil.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/utils/ExportFileNamesUtil.java
@@ -8,9 +8,9 @@ public class ExportFileNamesUtil {
 
   public static String getExportFileName(Measure measure) {
     if (measure.getModel().startsWith("QI-Core")) {
-      return measure.getEcqmTitle() + "-v" + measure.getVersion() + "-FHIR";
+      return measure.getEcqmTitle().trim() + "-v" + measure.getVersion() + "-FHIR";
     }
-    return measure.getEcqmTitle() + "-v" + measure.getVersion() + "-" + measure.getModel();
+    return measure.getEcqmTitle().trim() + "-v" + measure.getVersion() + "-" + measure.getModel();
   }
 
   public static String getTestCaseExportFileName(Measure measure, TestCase testCase) {

--- a/src/test/java/gov/cms/madie/madiefhirservice/utils/ExportFileNamesUtilTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/utils/ExportFileNamesUtilTest.java
@@ -1,5 +1,6 @@
 package gov.cms.madie.madiefhirservice.utils;
 
+import gov.cms.madie.models.common.ModelType;
 import gov.cms.madie.models.common.Version;
 import gov.cms.madie.models.measure.Measure;
 import gov.cms.madie.models.measure.TestCase;
@@ -18,8 +19,19 @@ public class ExportFileNamesUtilTest {
 
   @BeforeEach
   void setup() {
-    measure = Measure.builder().ecqmTitle("ecqm").version(Version.parse("1.0.000")).build();
+    measure =
+        Measure.builder()
+            .model(ModelType.QI_CORE.getValue())
+            .ecqmTitle("ecqm")
+            .version(Version.parse("1.0.000"))
+            .build();
     testCase = TestCase.builder().patientId(uuid).series("group").title("test").build();
+  }
+
+  @Test
+  void trimMeasureFileName() {
+    Measure msr = measure.toBuilder().ecqmTitle("   ecqm   ").build();
+    assertEquals("ecqm-v1.0.000-FHIR", ExportFileNamesUtil.getExportFileName(msr));
   }
 
   @Test


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-7961](https://jira.cms.gov/browse/MAT-7961)
(Optional) Related Tickets:

### Summary

Trim excess leading and trailing whitespace from the eCQM Abbreviated title when it is used in a filename.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
