### PR TITLE
MAT-8142, MAT-8176: Generate Bundles with ELM Error Severity Parameter

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/resources/MeasureBundleController.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/resources/MeasureBundleController.java
@@ -43,14 +43,14 @@ public class MeasureBundleController {
       @RequestBody @Validated(Measure.ValidationSequence.class) Measure measure,
       @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept,
       @RequestHeader("Authorization") String accessToken,
-      @RequestParam(defaultValue = "Info") CqlCompilerException.ErrorSeverity errorSeverity,
+      @RequestParam(defaultValue = "Info") CqlCompilerException.ErrorSeverity elmErrorSeverity,
       @RequestParam(required = false, defaultValue = "calculation", name = "bundleType")
           String bundleType) {
 
     try {
       Bundle bundle =
           measureBundleService.createMeasureBundle(
-              measure, request.getUserPrincipal(), bundleType, accessToken, errorSeverity);
+              measure, request.getUserPrincipal(), bundleType, accessToken, elmErrorSeverity);
 
       if (accept != null
           && accept.toUpperCase().contains(MediaType.APPLICATION_XML_VALUE.toUpperCase())) {
@@ -81,8 +81,8 @@ public class MeasureBundleController {
    *
    * @param request Web Request
    * @param measure Source measure
-   * @param elmErrorSeverity "Info" or "Error" expected, flag is passed to ELM Translator to set its error severity
-   *     level.
+   * @param elmErrorSeverity "Info" or "Error" expected, flag is passed to ELM Translator to set its
+   *     error severity level.
    * @param accessToken
    * @return zip export as byte[]
    */

--- a/src/main/java/gov/cms/madie/madiefhirservice/resources/MeasureBundleController.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/resources/MeasureBundleController.java
@@ -76,6 +76,16 @@ public class MeasureBundleController {
     }
   }
 
+  /**
+   * Export API outside measure-service so that FHIR model interactions only occur in this service.
+   *
+   * @param request Web Request
+   * @param measure Source measure
+   * @param elmErrorSeverity "Info" or "Error" expected, flag is passed to ELM Translator to set its error severity
+   *     level.
+   * @param accessToken
+   * @return zip export as byte[]
+   */
   @PutMapping(
       value = "/export",
       produces = {
@@ -87,6 +97,7 @@ public class MeasureBundleController {
   public ResponseEntity<byte[]> generateMeasureExport(
       HttpServletRequest request,
       @RequestBody @Validated(Measure.ValidationSequence.class) Measure measure,
+      @RequestParam(defaultValue = "Info") CqlCompilerException.ErrorSeverity elmErrorSeverity,
       @RequestHeader("Authorization") String accessToken) {
 
     return ResponseEntity.ok()
@@ -94,6 +105,8 @@ public class MeasureBundleController {
             HttpHeaders.CONTENT_DISPOSITION,
             "attachment;filename=\"" + ExportFileNamesUtil.getExportFileName(measure) + ".zip\"")
         .contentType(MediaType.APPLICATION_OCTET_STREAM)
-        .body(exportService.createExport(measure, request.getUserPrincipal(), accessToken));
+        .body(
+            exportService.createExport(
+                measure, request.getUserPrincipal(), elmErrorSeverity, accessToken));
   }
 }

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/CqlLibraryService.java
@@ -4,6 +4,7 @@ import gov.cms.madie.madiefhirservice.exceptions.CqlLibraryNotFoundException;
 import gov.cms.madie.models.library.CqlLibrary;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpEntity;
@@ -31,8 +32,12 @@ public class CqlLibraryService {
   private String librariesVersionedUri;
 
   @Cacheable(value = "libraries", key = "{ #root.methodName, #name, #version }")
-  public CqlLibrary getLibrary(String name, String version, String accessToken) {
-    URI uri = buildMadieLibraryServiceUri(name, version);
+  public CqlLibrary getLibrary(
+      String name,
+      String version,
+      String accessToken,
+      CqlCompilerException.ErrorSeverity errorSeverity) {
+    URI uri = buildMadieLibraryServiceUri(name, version, errorSeverity);
     HttpHeaders headers = new HttpHeaders();
     headers.add("Authorization", accessToken);
 
@@ -58,10 +63,12 @@ public class CqlLibraryService {
     return null;
   }
 
-  private URI buildMadieLibraryServiceUri(String name, String version) {
+  private URI buildMadieLibraryServiceUri(
+      String name, String version, CqlCompilerException.ErrorSeverity errorSeverity) {
     return UriComponentsBuilder.fromHttpUrl(madieLibraryService + librariesVersionedUri)
         .queryParam("name", name)
         .queryParam("version", version)
+        .queryParam("errorSeverity", errorSeverity)
         .build()
         .encode()
         .toUri();

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/ExportService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/ExportService.java
@@ -23,7 +23,11 @@ public class ExportService {
 
   private final MeasureBundleService measureBundleService;
 
-  public byte[] createExport(Measure madieMeasure, Principal principal, String accessToken) {
+  public byte[] createExport(
+      Measure madieMeasure,
+      Principal principal,
+      CqlCompilerException.ErrorSeverity errorSeverity,
+      String accessToken) {
     String exportFileName = ExportFileNamesUtil.getExportFileName(madieMeasure);
 
     Bundle bundle =
@@ -32,7 +36,7 @@ public class ExportService {
             principal,
             BundleUtil.MEASURE_BUNDLE_TYPE_EXPORT,
             accessToken,
-            CqlCompilerException.ErrorSeverity.Info);
+            errorSeverity);
 
     PackagingUtility utility;
     try {

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/LibraryService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/LibraryService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.hl7.fhir.r4.model.Attachment;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Narrative;
@@ -40,6 +41,7 @@ public class LibraryService {
       String cql,
       Map<String, Library> libraryMap,
       final String bundleType,
+      CqlCompilerException.ErrorSeverity errorSeverity,
       final String accessToken) {
     if (StringUtils.isBlank(cql) || libraryMap == null) {
       log.error("Invalid method arguments provided to getIncludedLibraries");
@@ -52,12 +54,16 @@ public class LibraryService {
       if (!libraryMap.containsKey(key)) {
         CqlLibrary cqlLibrary =
             cqlLibraryService.getLibrary(
-                libraryNameValuePair.getLeft(), libraryNameValuePair.getRight(), accessToken);
+                libraryNameValuePair.getLeft(),
+                libraryNameValuePair.getRight(),
+                accessToken,
+                errorSeverity);
         Library library = cqlLibraryToFhirLibrary(cqlLibrary, bundleType, accessToken);
         libraryMap.put(key, library);
 
         Attachment attachment = findCqlAttachment(library);
-        getIncludedLibraries(new String(attachment.getData()), libraryMap, bundleType, accessToken);
+        getIncludedLibraries(
+            new String(attachment.getData()), libraryMap, bundleType, errorSeverity, accessToken);
       }
     }
   }

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureBundleService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureBundleService.java
@@ -69,7 +69,7 @@ public class MeasureBundleService {
     // Bundle entries for all the library resources of a MADiE Measure
     List<Bundle.BundleEntryComponent> libraryEntryComponents =
         createBundleComponentsForLibrariesOfMadieMeasure(
-            expressions, madieMeasure, bundleType, accessToken);
+            expressions, madieMeasure, bundleType, errorSeverity, accessToken);
     libraryEntryComponents.forEach(bundle::addEntry);
     log.info("Included library components created successfully {}", madieMeasure.getId());
 
@@ -112,6 +112,7 @@ public class MeasureBundleService {
       Set<String> expressions,
       Measure madieMeasure,
       final String bundleType,
+      CqlCompilerException.ErrorSeverity errorSeverity,
       final String accessToken) {
     Library library =
         getMeasureLibraryResourceForMadieMeasure(expressions, madieMeasure, accessToken);
@@ -122,7 +123,7 @@ public class MeasureBundleService {
         FhirResourceHelpers.getBundleEntryComponent(library, "Transaction");
     Map<String, Library> includedLibraryMap = new HashMap<>();
     libraryService.getIncludedLibraries(
-        madieMeasure.getCql(), includedLibraryMap, bundleType, accessToken);
+        madieMeasure.getCql(), includedLibraryMap, bundleType, errorSeverity, accessToken);
     List<Bundle.BundleEntryComponent> libraryBundleComponents =
         includedLibraryMap.values().stream()
             .map((lib) -> FhirResourceHelpers.getBundleEntryComponent(lib, "Transaction"))

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/CqlLibraryServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/CqlLibraryServiceTest.java
@@ -3,6 +3,7 @@ package gov.cms.madie.madiefhirservice.services;
 import gov.cms.madie.madiefhirservice.exceptions.CqlLibraryNotFoundException;
 import gov.cms.madie.models.common.Version;
 import gov.cms.madie.models.library.CqlLibrary;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,7 +52,9 @@ class CqlLibraryServiceTest {
     when(restTemplate.exchange(
             any(URI.class), any(HttpMethod.class), any(HttpEntity.class), any(Class.class)))
         .thenReturn(response);
-    CqlLibrary output = cqlLibraryService.getLibrary("FHIRHelpers", "4.0.001", "OKTA_TOKEN");
+    CqlLibrary output =
+        cqlLibraryService.getLibrary(
+            "FHIRHelpers", "4.0.001", "OKTA_TOKEN", CqlCompilerException.ErrorSeverity.Info);
     assertThat(output, is(notNullValue()));
     assertThat(output, is(equalTo(theLibrary)));
   }
@@ -65,7 +68,12 @@ class CqlLibraryServiceTest {
     Exception ex =
         assertThrows(
             CqlLibraryNotFoundException.class,
-            () -> cqlLibraryService.getLibrary("FHIRHelpers", "4.0.001", "OKTA_TOKEN"));
+            () ->
+                cqlLibraryService.getLibrary(
+                    "FHIRHelpers",
+                    "4.0.001",
+                    "OKTA_TOKEN",
+                    CqlCompilerException.ErrorSeverity.Info));
     assertThat(
         ex.getMessage(),
         is(equalTo("Cannot find a CQL Library with name: FHIRHelpers, version: 4.0.001")));
@@ -77,7 +85,9 @@ class CqlLibraryServiceTest {
     when(restTemplate.exchange(
             any(URI.class), any(HttpMethod.class), any(HttpEntity.class), any(Class.class)))
         .thenReturn(response);
-    CqlLibrary output = cqlLibraryService.getLibrary("FHIRHelpers", "4.0.001", "OKTA_TOKEN");
+    CqlLibrary output =
+        cqlLibraryService.getLibrary(
+            "FHIRHelpers", "4.0.001", "OKTA_TOKEN", CqlCompilerException.ErrorSeverity.Info);
     assertThat(output, is(nullValue()));
   }
 
@@ -87,7 +97,9 @@ class CqlLibraryServiceTest {
     when(restTemplate.exchange(
             any(URI.class), any(HttpMethod.class), any(HttpEntity.class), any(Class.class)))
         .thenReturn(response);
-    CqlLibrary output = cqlLibraryService.getLibrary("FHIRHelpers", "4.0.001", "OKTA_TOKEN");
+    CqlLibrary output =
+        cqlLibraryService.getLibrary(
+            "FHIRHelpers", "4.0.001", "OKTA_TOKEN", CqlCompilerException.ErrorSeverity.Info);
     assertThat(output, is(nullValue()));
   }
 }

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/ExportServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/ExportServiceTest.java
@@ -97,13 +97,15 @@ class ExportServiceTest implements ResourceFileUtil {
     PackagingUtilityImpl utility = Mockito.mock(PackagingUtilityImpl.class);
 
     factory.when(() -> PackagingUtilityFactory.getInstance("QI-Core v4.1.1")).thenReturn(utility);
-    doReturn("THis is a test".getBytes())
+    doReturn("This is a test".getBytes())
         .when(utility)
         .getZipBundle(any(Bundle.class), any(String.class));
 
-    byte[] result = exportService.createExport(madieMeasure, principal, "Bearer TOKEN");
+    byte[] result =
+        exportService.createExport(
+            madieMeasure, principal, CqlCompilerException.ErrorSeverity.Info, "Bearer TOKEN");
 
-    assertThat(result, is(equalTo("THis is a test".getBytes())));
+    assertThat(result, is(equalTo("This is a test".getBytes())));
   }
 
   @Test
@@ -118,7 +120,12 @@ class ExportServiceTest implements ResourceFileUtil {
     Exception ex =
         assertThrows(
             RuntimeException.class,
-            () -> exportService.createExport(madieMeasure, principal, "Bearer TOKEN"));
+            () ->
+                exportService.createExport(
+                    madieMeasure,
+                    principal,
+                    CqlCompilerException.ErrorSeverity.Info,
+                    "Bearer TOKEN"));
     assertThat(
         ex.getMessage(),
         is(equalTo("Unexpected error while generating exports for measureID: xyz-p13r-13ert")));

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/LibraryServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/LibraryServiceTest.java
@@ -7,6 +7,7 @@ import gov.cms.madie.madiefhirservice.utils.LibraryHelper;
 import gov.cms.madie.madiefhirservice.utils.ResourceFileUtil;
 import gov.cms.madie.models.common.Version;
 import gov.cms.madie.models.library.CqlLibrary;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.hl7.fhir.r4.model.Attachment;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Library;
@@ -81,14 +82,19 @@ class LibraryServiceTest implements LibraryHelper, ResourceFileUtil {
             .build();
 
     when(libCqlVisitorFactory.visit(anyString())).thenReturn(visitor1).thenReturn(visitor2);
-    when(cqlLibraryService.getLibrary(anyString(), anyString(), anyString()))
+    when(cqlLibraryService.getLibrary(
+            anyString(), anyString(), anyString(), any(CqlCompilerException.ErrorSeverity.class)))
         .thenReturn(cqlLibrary);
     when(libraryTranslatorService.convertToFhirLibrary(any(CqlLibrary.class), any(), anyString()))
         .thenReturn(library);
 
     Map<String, Library> includedLibraryMap = new HashMap<>();
     libraryService.getIncludedLibraries(
-        mainLibrary, includedLibraryMap, BundleUtil.MEASURE_BUNDLE_TYPE_EXPORT, "TOKEN");
+        mainLibrary,
+        includedLibraryMap,
+        BundleUtil.MEASURE_BUNDLE_TYPE_EXPORT,
+        CqlCompilerException.ErrorSeverity.Info,
+        "TOKEN");
     assertThat(includedLibraryMap.size(), is(equalTo(1)));
     assertNotNull(includedLibraryMap.get("IncludedLibrary0.1.000"));
   }
@@ -103,7 +109,11 @@ class LibraryServiceTest implements LibraryHelper, ResourceFileUtil {
             IllegalArgumentException.class,
             () ->
                 libraryService.getIncludedLibraries(
-                    mainLibrary, libraries, BundleUtil.MEASURE_BUNDLE_TYPE_EXPORT, "TOKEN"));
+                    mainLibrary,
+                    libraries,
+                    BundleUtil.MEASURE_BUNDLE_TYPE_EXPORT,
+                    CqlCompilerException.ErrorSeverity.Info,
+                    "TOKEN"));
 
     assertThat(exception.getMessage(), is(equalTo("Please provide valid arguments.")));
   }
@@ -122,7 +132,8 @@ class LibraryServiceTest implements LibraryHelper, ResourceFileUtil {
     var visitor2 = new LibraryCqlVisitorFactory().visit(includedLibrary);
 
     when(libCqlVisitorFactory.visit(anyString())).thenReturn(visitor1).thenReturn(visitor2);
-    when(cqlLibraryService.getLibrary(anyString(), anyString(), anyString()))
+    when(cqlLibraryService.getLibrary(
+            anyString(), anyString(), anyString(), any(CqlCompilerException.ErrorSeverity.class)))
         .thenThrow(new CqlLibraryNotFoundException("Test Exception Here!", "0.1.000"));
 
     Map<String, Library> libraries = new HashMap<>();
@@ -131,7 +142,11 @@ class LibraryServiceTest implements LibraryHelper, ResourceFileUtil {
             CqlLibraryNotFoundException.class,
             () ->
                 libraryService.getIncludedLibraries(
-                    mainLibrary, libraries, BundleUtil.MEASURE_BUNDLE_TYPE_EXPORT, "TOKEN"));
+                    mainLibrary,
+                    libraries,
+                    BundleUtil.MEASURE_BUNDLE_TYPE_EXPORT,
+                    CqlCompilerException.ErrorSeverity.Info,
+                    "TOKEN"));
 
     assertThat(
         exception.getMessage(),

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureBundleServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureBundleServiceTest.java
@@ -88,7 +88,12 @@ public class MeasureBundleServiceTest implements ResourceFileUtil {
               return null;
             })
         .when(libraryService)
-        .getIncludedLibraries(anyString(), anyMap(), anyString(), anyString());
+        .getIncludedLibraries(
+            anyString(),
+            anyMap(),
+            anyString(),
+            any(CqlCompilerException.ErrorSeverity.class),
+            anyString());
 
     Bundle bundle =
         measureBundleService.createMeasureBundle(
@@ -136,7 +141,12 @@ public class MeasureBundleServiceTest implements ResourceFileUtil {
 
     doThrow(new CqlLibraryNotFoundException("FHIRHelpers", "4.0.001"))
         .when(libraryService)
-        .getIncludedLibraries(anyString(), any(), anyString(), anyString());
+        .getIncludedLibraries(
+            anyString(),
+            any(),
+            anyString(),
+            any(CqlCompilerException.ErrorSeverity.class),
+            anyString());
     Exception exception =
         Assertions.assertThrows(
             CqlLibraryNotFoundException.class,
@@ -169,7 +179,12 @@ public class MeasureBundleServiceTest implements ResourceFileUtil {
               return null;
             })
         .when(libraryService)
-        .getIncludedLibraries(anyString(), anyMap(), anyString(), anyString());
+        .getIncludedLibraries(
+            anyString(),
+            anyMap(),
+            anyString(),
+            any(CqlCompilerException.ErrorSeverity.class),
+            anyString());
 
     when(elmTranslatorClient.getEffectiveDataRequirements(
             any(CqlLibraryDetails.class),

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/TestCaseBundleServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/TestCaseBundleServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.doReturn;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -442,8 +441,7 @@ class TestCaseBundleServiceTest implements ResourceFileUtil {
 
   //  @Disabled
   @Test
-  void zipTestCaseContents()
-      throws IOException {
+  void zipTestCaseContents() throws IOException {
 
     Map<String, Bundle> testCaseBundleMap = new HashMap<>();
     testCaseBundleMap.put(

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/TestCaseBundleServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/TestCaseBundleServiceTest.java
@@ -179,7 +179,7 @@ class TestCaseBundleServiceTest implements ResourceFileUtil {
     PackagingUtilityImpl utility = Mockito.mock(PackagingUtilityImpl.class);
 
     factory.when(() -> PackagingUtilityFactory.getInstance("QI-Core v4.1.1")).thenReturn(utility);
-    doReturn("THis is a test".getBytes()).when(utility).getZipBundle(any(), isNull());
+    doReturn("This is a test".getBytes()).when(utility).getZipBundle(any(), isNull());
     IParser parser =
         fhirContext
             .newJsonParser()
@@ -443,12 +443,7 @@ class TestCaseBundleServiceTest implements ResourceFileUtil {
   //  @Disabled
   @Test
   void zipTestCaseContents()
-      throws IOException,
-          ClassNotFoundException,
-          InvocationTargetException,
-          InstantiationException,
-          IllegalAccessException,
-          NoSuchMethodException {
+      throws IOException {
 
     Map<String, Bundle> testCaseBundleMap = new HashMap<>();
     testCaseBundleMap.put(


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-8142](https://jira.cms.gov/browse/MAT-8142), [MAT-8176](https://jira.cms.gov/browse/MAT-8176)
(Optional) Related Tickets:

### Summary

Expose ELM Error Severity parameter on export endpoint.

Use ELM Error Severity parameter during bundle creation.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
