### PR TITLE
[MAT-8216] Rework Liquid Engine resource loading for docker

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
@@ -3,6 +3,7 @@ package gov.cms.madie.madiefhirservice.config;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.DefaultProfileValidationSupport;
 import ca.uhn.fhir.context.support.IValidationSupport;
+import ca.uhn.fhir.util.ClasspathUtil;
 import ca.uhn.fhir.validation.FhirValidator;
 import ca.uhn.fhir.validation.IValidatorModule;
 import gov.cms.madie.madiefhirservice.utils.QiCoreLenientTerminologyValidator;
@@ -18,9 +19,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Objects;
+import java.io.InputStream;
 
 @Slf4j
 @Configuration
@@ -122,20 +122,17 @@ public class HapiFhirConfig {
   public LiquidEngine liquidEngine() throws IOException {
     // WorkerContext based on NPM package used per guidance provided in
     // https://github.com/cqframework/sample-content-ig/issues/121#issuecomment-2725717942
-    NpmPackage pkg =
-        NpmPackage.fromPackage(
-            new FileInputStream(
-                Objects.requireNonNull(
-                        getClass().getClassLoader().getResource("packages/hl7.fhir.r5.core.tgz"))
-                    .getFile()));
-    var ctx =
-        new SimpleWorkerContext.SimpleWorkerContextBuilder()
-            .withAllowLoadingDuplicates(true)
-            .fromPackage(pkg);
-    LiquidEngine liquidEngine = new LiquidEngine(ctx, null);
-    liquidEngine.setIncludeResolver(new IncludeResolver());
+    try (InputStream is =
+        ClasspathUtil.loadResourceAsStream("classpath:packages/hl7.fhir.r5.core.tgz")) {
+      var ctx =
+          new SimpleWorkerContext.SimpleWorkerContextBuilder()
+              .withAllowLoadingDuplicates(true)
+              .fromPackage(NpmPackage.fromPackage(is));
+      LiquidEngine liquidEngine = new LiquidEngine(ctx, null);
+      liquidEngine.setIncludeResolver(new IncludeResolver());
 
-    return liquidEngine;
+      return liquidEngine;
+    }
   }
 
   static class IncludeResolver implements LiquidEngine.ILiquidEngineIncludeResolver {


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-8216](https://jira.cms.gov/browse/MAT-8216)
(Optional) Related Tickets:

### Summary

Use FHIR's ClasspathUtil class to load the R5 NPM package needed by Liquid Engine to correctly render templates using FHIR Liquid Engine global references (e.g., `Resource`). My previous implementation did not work from within docker.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
