### PR TITLE
[MAT-8370] Move Measure Definitions to Measure Ext per QMIG

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/constants/UriConstants.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/constants/UriConstants.java
@@ -79,7 +79,9 @@ public final class UriConstants {
         "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-supplementalDataGuidance";
 
     public static final String MEASURE_DEFINITION_EXT_URI =
-        "http://hl7.org/fhir/5.0/StructureDefinition/extension-Measure.term";
+        // TODO Use this URL once liquid templates are updated:
+        //  "http://hl7.org/fhir/5.0/StructureDefinition/extension-Measure.term";
+        "http://hl7.org/fhir/StructureDefinition/cqf-definitionTerm";
 
     public static final String INCLUDE_IN_REPORT_TYPE_URI =
         "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-includeInReportType";

--- a/src/main/java/gov/cms/madie/madiefhirservice/constants/UriConstants.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/constants/UriConstants.java
@@ -78,6 +78,9 @@ public final class UriConstants {
     public static final String SUPPLEMENTAL_DATA_GUIDANCE_URI =
         "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-supplementalDataGuidance";
 
+    public static final String MEASURE_DEFINITION_EXT_URI =
+        "http://hl7.org/fhir/5.0/StructureDefinition/extension-Measure.term";
+
     public static final String INCLUDE_IN_REPORT_TYPE_URI =
         "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-includeInReportType";
 

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
@@ -254,7 +254,7 @@ public class MeasureTranslatorService {
             identifierType.getCode(),
             UriConstants.CodeSystem.CODE_SYSTEM_IDENTIFIER_TYPE_URI,
             identifierType.getDisplay()));
-    log.info("\nbuildIdentifier: identifier = " + identifier.toString());
+    log.debug("\nbuildIdentifier: identifier = {}", identifier.getValue());
     return identifier;
   }
 

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorService.java
@@ -29,6 +29,8 @@ import gov.cms.madie.madiefhirservice.constants.UriConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -53,7 +55,6 @@ public class MeasureTranslatorService {
         .setApprovalDate(getApprovalDate(madieMeasure))
         .setLastReviewDate(getLastReviewDate(madieMeasure))
         .setPublisher(getStewardName(steward))
-        .setDefinition(buildDefinitions(madieMeasure))
         .setCopyright(getCopyright(madieMeasure))
         .setDisclaimer(getDisclaimer(madieMeasure))
         .setRationale(madieMeasure.getMeasureMetaData().getRationale())
@@ -149,6 +150,10 @@ public class MeasureTranslatorService {
     Extension riskAdjustmentVariableGuidanceExt = buildRiskAdjustmentGuidanceExt(madieMeasure);
     if (riskAdjustmentVariableGuidanceExt != null) {
       extensions.add(riskAdjustmentVariableGuidanceExt);
+    }
+    List<Extension> measureDefinitionsExts = buildMeasureDefinitionExts(madieMeasure);
+    if (isNotEmpty(measureDefinitionsExts)) {
+      extensions.addAll(measureDefinitionsExts);
     }
     return extensions;
   }
@@ -495,7 +500,7 @@ public class MeasureTranslatorService {
                   strat -> {
                     List<PopulationType> associations = strat.getAssociations();
                     MeasureGroupStratifierComponent stratComponent = null;
-                    if (CollectionUtils.isNotEmpty(associations)) {
+                    if (isNotEmpty(associations)) {
                       List<Extension> extensionList =
                           associations.stream()
                               .map(
@@ -702,6 +707,30 @@ public class MeasureTranslatorService {
     return ext;
   }
 
+  /**
+   * Build extension for each measure definition. Assumes that each measure definition contains a
+   * Term and Definition of that Term.
+   *
+   * @param madieMeasure
+   * @return List of Extensions where each Extension represents a measure definition.
+   */
+  private List<Extension> buildMeasureDefinitionExts(Measure madieMeasure) {
+    if (CollectionUtils.isEmpty(madieMeasure.getMeasureMetaData().getMeasureDefinitions())) {
+      return Collections.emptyList();
+    }
+
+    return madieMeasure.getMeasureMetaData().getMeasureDefinitions().stream()
+        .map(
+            msrDef -> {
+              Extension ext = new Extension(UriConstants.CqfMeasures.MEASURE_DEFINITION_EXT_URI);
+              ext.addExtension(new Extension("term", new StringType(msrDef.getTerm())));
+              ext.addExtension(
+                  new Extension("definition", new MarkdownType(msrDef.getDefinition())));
+              return ext;
+            })
+        .collect(Collectors.toList());
+  }
+
   private List<MeasureSupplementalDataComponent> buildSupplementalDataElements(
       Measure madieMeasure) {
     if (madieMeasure.getSupplementalData() == null) {
@@ -722,7 +751,7 @@ public class MeasureTranslatorService {
                           "supplemental-data",
                           "http://terminology.hl7.org/CodeSystem/measure-data-usage",
                           null)));
-              if (CollectionUtils.isNotEmpty(supplementalData.getIncludeInReportType())) {
+              if (isNotEmpty(supplementalData.getIncludeInReportType())) {
                 supplementalData
                     .getIncludeInReportType()
                     .forEach(
@@ -754,7 +783,7 @@ public class MeasureTranslatorService {
                           "http://terminology.hl7.org/CodeSystem/measure-data-usage",
                           null)));
               measureSupplementalDataComponent.setDescription(riskAdjustment.getDefinition());
-              if (CollectionUtils.isNotEmpty(riskAdjustment.getIncludeInReportType())) {
+              if (isNotEmpty(riskAdjustment.getIncludeInReportType())) {
                 riskAdjustment
                     .getIncludeInReportType()
                     .forEach(
@@ -771,22 +800,6 @@ public class MeasureTranslatorService {
     return new Extension(
         UriConstants.CqfMeasures.INCLUDE_IN_REPORT_TYPE_URI,
         new CodeType(measureReportType.toCode()));
-  }
-
-  private List<MarkdownType> buildDefinitions(Measure madieMeasure) {
-    List<MarkdownType> definitions = null;
-    if (madieMeasure.getMeasureMetaData() != null
-        && !CollectionUtils.isEmpty(madieMeasure.getMeasureMetaData().getMeasureDefinitions())) {
-      definitions =
-          madieMeasure.getMeasureMetaData().getMeasureDefinitions().stream()
-              .map(
-                  definition -> {
-                    return new MarkdownType(
-                        definition.getTerm() + " - " + definition.getDefinition() + "\n");
-                  })
-              .collect(Collectors.toList());
-    }
-    return definitions;
   }
 
   private List<RelatedArtifact> buildRelatedArtifacts(

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/MeasureTranslatorServiceTest.java
@@ -412,9 +412,22 @@ public class MeasureTranslatorServiceTest implements ResourceFileUtil {
     assertFalse(measure.getSupplementalData().get(2).getUsage().get(0).getCoding().isEmpty());
     assertEquals("0.0.000", measure.getVersion());
 
-    assertEquals(measure.getDefinition().size(), 2);
-    assertEquals(measure.getDefinition().get(0).toString(), "test term1 - test definition1" + "\n");
-    assertEquals(measure.getDefinition().get(1).toString(), "test term2 - test definition2" + "\n");
+    assertThat(measure.hasExtension(UriConstants.CqfMeasures.MEASURE_DEFINITION_EXT_URI), is(true));
+    List<Extension> measureDefinitionExtensions =
+        measure.getExtensionsByUrl(UriConstants.CqfMeasures.MEASURE_DEFINITION_EXT_URI);
+
+    assertEquals(2, measureDefinitionExtensions.size());
+    for (int i = 0; i < measureDefinitionExtensions.size(); i++) {
+      assertEquals(2, measureDefinitionExtensions.get(i).getExtension().size());
+      assertThat(measureDefinitionExtensions.get(i).hasExtension("term"), is(true));
+      assertThat(measureDefinitionExtensions.get(i).hasExtension("definition"), is(true));
+      assertThat(
+          measureDefinitionExtensions.get(i).getExtension().get(0).getValue().toString(),
+          is(madieMeasure.getMeasureMetaData().getMeasureDefinitions().get(i).getTerm()));
+      assertThat(
+          measureDefinitionExtensions.get(i).getExtension().get(1).getValue().toString(),
+          is(madieMeasure.getMeasureMetaData().getMeasureDefinitions().get(i).getDefinition()));
+    }
   }
 
   @Test


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-8370](https://jira.cms.gov/browse/MAT-8370)
(Optional) Related Tickets:

### Summary
To display Measure Definitions in the FHIR HR the values need to be populated, per QMIG, as Measure extensions with the specified url and structure. 

Each Definition should have an array of 2 Extensions: term - containing the term value, and definition - containing the definition text.

![Screenshot 2025-05-08 at 4 23 45 PM](https://github.com/user-attachments/assets/2166ab86-6296-4fca-a01d-5997d6dd1ac1)

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
