### PR TITLE
MAT-9115 revert the HAPI FHIR v8 update that is breaking in-memory terminology validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<springfox.version>3.0.0</springfox.version>
-        <hapi.fhir.r4.version>8.4.0</hapi.fhir.r4.version>
+		<hapi.fhir.r4.version>7.6.1</hapi.fhir.r4.version>
 		<cqframework.version>3.29.0</cqframework.version>
 		<org.fhir.ucum.version>1.0.9</org.fhir.ucum.version>
 	</properties>

--- a/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
@@ -17,7 +17,7 @@ import org.hl7.fhir.common.hapi.validation.validator.FhirInstanceValidator;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.hl7.fhir.r5.context.SimpleWorkerContext;
-import org.hl7.fhir.r5.liquid.LiquidEngine;
+import org.hl7.fhir.r5.utils.LiquidEngine;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -107,14 +107,15 @@ public class HapiFhirConfig {
     RemoteTerminologyServiceValidationSupport remoteTerminologyServiceValidationSupport =
         getRemoteTerminologyServiceValidationSupport(qicore6FhirContext);
 
-    return new ValidationSupportChain(
-        prePopulatedValidationSupport,
-        npmPackageSupport,
-        new DefaultProfileValidationSupport(qicore6FhirContext),
-        new CustomQiCoreInMemoryValidationSupport(qicore6FhirContext, validationConfig),
-        new CommonCodeSystemsTerminologyService(qicore6FhirContext),
-        remoteTerminologyServiceValidationSupport,
-        unknownCodeSystemWarningValidationSupport);
+    return new CachingValidationSupport(
+        new ValidationSupportChain(
+            prePopulatedValidationSupport,
+            npmPackageSupport,
+            new DefaultProfileValidationSupport(qicore6FhirContext),
+            new CustomQiCoreInMemoryValidationSupport(qicore6FhirContext, validationConfig),
+            new CommonCodeSystemsTerminologyService(qicore6FhirContext),
+            remoteTerminologyServiceValidationSupport,
+            unknownCodeSystemWarningValidationSupport));
   }
 
   public RemoteTerminologyServiceValidationSupport getRemoteTerminologyServiceValidationSupport(

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/HumanReadableService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/HumanReadableService.java
@@ -10,8 +10,8 @@ import org.hl7.fhir.convertors.conv40_50.VersionConvertor_40_50;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Resource;
-import org.hl7.fhir.r5.liquid.LiquidEngine;
 import org.hl7.fhir.r5.model.*;
+import org.hl7.fhir.r5.utils.LiquidEngine;
 import org.springframework.stereotype.Service;
 
 import java.util.*;

--- a/src/main/java/gov/cms/madie/madiefhirservice/utils/LenientTerminologyValidator.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/utils/LenientTerminologyValidator.java
@@ -203,4 +203,9 @@ class LenientTerminologyValidator implements IValidationSupport {
   public String getName() {
     return inMemoryTerminologyServerValidationSupport.getName();
   }
+
+  @Override
+  public boolean isEnabledValidationForCodingsLogicalAnd() {
+    return inMemoryTerminologyServerValidationSupport.isEnabledValidationForCodingsLogicalAnd();
+  }
 }

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/HumanReadableServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/HumanReadableServiceTest.java
@@ -25,7 +25,7 @@ import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
 import org.hl7.fhir.r5.context.SimpleWorkerContext;
-import org.hl7.fhir.r5.liquid.LiquidEngine;
+import org.hl7.fhir.r5.utils.LiquidEngine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/ResourceValidationServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/ResourceValidationServiceTest.java
@@ -11,7 +11,9 @@ import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Procedure;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -37,42 +39,52 @@ class ResourceValidationServiceTest {
 
   @InjectMocks ResourceValidationService validationService;
 
+  private MockedStatic<BundleUtil> bundleUtilMock;
+
   @BeforeAll
   public static void setup() {
     fhirContext = FhirContext.forR4();
     r5FhirContext = FhirContext.forR5();
   }
 
-  @Test
-  void testValidateBundleResourcesProfilesReturnsNoIssuesForEmptyBundle() {
-    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
-      utilities
-          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-          .thenReturn(List.of());
-      Bundle bundle = new Bundle();
-      OperationOutcome output =
-          (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
-      assertThat(output, is(notNullValue()));
-      assertThat(output.hasIssue(), is(false));
+  @BeforeEach
+  void setupMocks() {
+    bundleUtilMock = Mockito.mockStatic(BundleUtil.class);
+  }
+
+  @AfterEach
+  void tearDownMocks() {
+    if (bundleUtilMock != null) {
+      bundleUtilMock.close();
     }
   }
 
   @Test
-  void testValidateBundleResourcesProfilesReturnsIssueForMissingProfile() {
-    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
-      utilities
-          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-          .thenReturn(List.of(new Patient(), new Encounter()));
+  void testValidateBundleResourcesProfilesReturnsNoIssuesForEmptyBundle() {
+    bundleUtilMock
+        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+        .thenReturn(List.of());
+    Bundle bundle = new Bundle();
+    OperationOutcome output =
+        (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
+    assertThat(output, is(notNullValue()));
+    assertThat(output.hasIssue(), is(false));
+  }
 
-      Bundle bundle = new Bundle();
-      OperationOutcome output =
-          (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
-      assertThat(output, is(notNullValue()));
-      assertThat(output.hasIssue(), is(true));
-      // empty profiles for Patient and Encounter has 2 issues, required profile missing adds
-      // another one
-      assertThat(output.getIssue().size(), is(equalTo(2)));
-    }
+  @Test
+  void testValidateBundleResourcesProfilesReturnsIssueForMissingProfile() {
+    bundleUtilMock
+        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+        .thenReturn(List.of(new Patient(), new Encounter()));
+
+    Bundle bundle = new Bundle();
+    OperationOutcome output =
+        (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
+    assertThat(output, is(notNullValue()));
+    assertThat(output.hasIssue(), is(true));
+    // empty profiles for Patient and Encounter has 2 issues, required profile missing adds
+    // another one
+    assertThat(output.getIssue().size(), is(equalTo(2)));
   }
 
   @Test
@@ -81,18 +93,16 @@ class ResourceValidationServiceTest {
     p.getMeta().addProfile(UriConstants.QiCore.PATIENT_PROFILE_URI);
     Encounter encounter = new Encounter();
     encounter.getMeta().addProfile("invalidURL");
-    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
-      utilities
-          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-          .thenReturn(List.of(p, encounter));
+    bundleUtilMock
+        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+        .thenReturn(List.of(p, encounter));
 
-      Bundle bundle = new Bundle();
-      OperationOutcome output =
-          (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
-      assertThat(output, is(notNullValue()));
-      assertThat(output.hasIssue(), is(true));
-      assertThat(output.getIssue().size(), is(equalTo(1)));
-    }
+    Bundle bundle = new Bundle();
+    OperationOutcome output =
+        (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
+    assertThat(output, is(notNullValue()));
+    assertThat(output.hasIssue(), is(true));
+    assertThat(output.getIssue().size(), is(equalTo(1)));
   }
 
   @Test
@@ -101,18 +111,16 @@ class ResourceValidationServiceTest {
     p.getMeta().addProfile(UriConstants.QiCore.PATIENT_PROFILE_URI);
     Encounter encounter = new Encounter();
     encounter.getMeta().addProfile("http://localhost:8080/measures/id?s=^IXIC");
-    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
-      utilities
-          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-          .thenReturn(List.of(p, encounter));
+    bundleUtilMock
+        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+        .thenReturn(List.of(p, encounter));
 
-      Bundle bundle = new Bundle();
-      OperationOutcome output =
-          (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
-      assertThat(output, is(notNullValue()));
-      assertThat(output.hasIssue(), is(true));
-      assertThat(output.getIssue().size(), is(equalTo(1)));
-    }
+    Bundle bundle = new Bundle();
+    OperationOutcome output =
+        (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
+    assertThat(output, is(notNullValue()));
+    assertThat(output.hasIssue(), is(true));
+    assertThat(output.getIssue().size(), is(equalTo(1)));
   }
 
   @Test
@@ -121,17 +129,15 @@ class ResourceValidationServiceTest {
     p.getMeta().addProfile(UriConstants.QiCore.PATIENT_PROFILE_URI);
     Encounter encounter = new Encounter();
     encounter.getMeta().addProfile("http://test.profile.com");
-    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
-      utilities
-          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-          .thenReturn(List.of(p, encounter));
+    bundleUtilMock
+        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+        .thenReturn(List.of(p, encounter));
 
-      Bundle bundle = new Bundle();
-      OperationOutcome output =
-          (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
-      assertThat(output, is(notNullValue()));
-      assertThat(output.hasIssue(), is(false));
-    }
+    Bundle bundle = new Bundle();
+    OperationOutcome output =
+        (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
+    assertThat(output, is(notNullValue()));
+    assertThat(output.hasIssue(), is(false));
   }
 
   @Test
@@ -142,18 +148,16 @@ class ResourceValidationServiceTest {
     e1.setId("1234");
     Encounter e2 = new Encounter();
     e2.setId("1234");
-    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
-      utilities
-          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-          .thenReturn(List.of(p, e1, e2));
+    bundleUtilMock
+        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+        .thenReturn(List.of(p, e1, e2));
 
-      Bundle bundle = new Bundle();
-      OperationOutcome output =
-          (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
-      assertThat(output, is(notNullValue()));
-      assertThat(output.hasIssue(), is(true));
-      assertThat(output.getIssueFirstRep().getDiagnostics().contains("1234"), is(true));
-    }
+    Bundle bundle = new Bundle();
+    OperationOutcome output =
+        (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
+    assertThat(output, is(notNullValue()));
+    assertThat(output.hasIssue(), is(true));
+    assertThat(output.getIssueFirstRep().getDiagnostics().contains("1234"), is(true));
   }
 
   @Test
@@ -166,19 +170,17 @@ class ResourceValidationServiceTest {
     p1.setId("1234");
     Encounter e2 = new Encounter();
     e2.setId("3456");
-    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
-      utilities
-          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-          .thenReturn(List.of(p, e1, p1, e2));
+    bundleUtilMock
+        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+        .thenReturn(List.of(p, e1, p1, e2));
 
-      Bundle bundle = new Bundle();
-      OperationOutcome output =
-          (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
-      assertThat(output, is(notNullValue()));
-      assertThat(output.hasIssue(), is(true));
-      assertThat(output.getIssueFirstRep().getDiagnostics().contains("1234"), is(true));
-      assertThat(output.getIssue().size(), is(equalTo(1)));
-    }
+    Bundle bundle = new Bundle();
+    OperationOutcome output =
+        (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
+    assertThat(output, is(notNullValue()));
+    assertThat(output.hasIssue(), is(true));
+    assertThat(output.getIssueFirstRep().getDiagnostics().contains("1234"), is(true));
+    assertThat(output.getIssue().size(), is(equalTo(1)));
   }
 
   @Test
@@ -189,17 +191,15 @@ class ResourceValidationServiceTest {
     e1.setId("2222");
     Encounter e2 = new Encounter();
     e2.setId("3333");
-    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
-      utilities
-          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-          .thenReturn(List.of(p, e1, e2));
+    bundleUtilMock
+        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+        .thenReturn(List.of(p, e1, e2));
 
-      Bundle bundle = new Bundle();
-      OperationOutcome output =
-          (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
-      assertThat(output, is(notNullValue()));
-      assertThat(output.hasIssue(), is(false));
-    }
+    Bundle bundle = new Bundle();
+    OperationOutcome output =
+        (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
+    assertThat(output, is(notNullValue()));
+    assertThat(output.hasIssue(), is(false));
   }
 
   @Test
@@ -209,18 +209,16 @@ class ResourceValidationServiceTest {
     e1.setId("2222");
     Encounter e2 = new Encounter();
     e2.setId("3333");
-    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
-      utilities
-          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-          .thenReturn(List.of(p, e1, e2));
+    bundleUtilMock
+        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+        .thenReturn(List.of(p, e1, e2));
 
-      Bundle bundle = new Bundle();
-      OperationOutcome output =
-          (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
-      assertThat(output, is(notNullValue()));
-      assertThat(output.hasIssue(), is(true));
-      assertEquals(output.getIssueFirstRep().getDiagnostics(), "All resources must have an Id");
-    }
+    Bundle bundle = new Bundle();
+    OperationOutcome output =
+        (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
+    assertThat(output, is(notNullValue()));
+    assertThat(output.hasIssue(), is(true));
+    assertEquals("All resources must have an Id", output.getIssueFirstRep().getDiagnostics());
   }
 
   @Test

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/ResourceValidationServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/ResourceValidationServiceTest.java
@@ -11,9 +11,7 @@ import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Procedure;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -39,52 +37,42 @@ class ResourceValidationServiceTest {
 
   @InjectMocks ResourceValidationService validationService;
 
-  private MockedStatic<BundleUtil> bundleUtilMock;
-
   @BeforeAll
   public static void setup() {
     fhirContext = FhirContext.forR4();
     r5FhirContext = FhirContext.forR5();
   }
 
-  @BeforeEach
-  void setupMocks() {
-    bundleUtilMock = Mockito.mockStatic(BundleUtil.class);
-  }
-
-  @AfterEach
-  void tearDownMocks() {
-    if (bundleUtilMock != null) {
-      bundleUtilMock.close();
+  @Test
+  void testValidateBundleResourcesProfilesReturnsNoIssuesForEmptyBundle() {
+    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
+      utilities
+          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+          .thenReturn(List.of());
+      Bundle bundle = new Bundle();
+      OperationOutcome output =
+          (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
+      assertThat(output, is(notNullValue()));
+      assertThat(output.hasIssue(), is(false));
     }
   }
 
   @Test
-  void testValidateBundleResourcesProfilesReturnsNoIssuesForEmptyBundle() {
-    bundleUtilMock
-        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-        .thenReturn(List.of());
-    Bundle bundle = new Bundle();
-    OperationOutcome output =
-        (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
-    assertThat(output, is(notNullValue()));
-    assertThat(output.hasIssue(), is(false));
-  }
-
-  @Test
   void testValidateBundleResourcesProfilesReturnsIssueForMissingProfile() {
-    bundleUtilMock
-        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-        .thenReturn(List.of(new Patient(), new Encounter()));
+    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
+      utilities
+          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+          .thenReturn(List.of(new Patient(), new Encounter()));
 
-    Bundle bundle = new Bundle();
-    OperationOutcome output =
-        (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
-    assertThat(output, is(notNullValue()));
-    assertThat(output.hasIssue(), is(true));
-    // empty profiles for Patient and Encounter has 2 issues, required profile missing adds
-    // another one
-    assertThat(output.getIssue().size(), is(equalTo(2)));
+      Bundle bundle = new Bundle();
+      OperationOutcome output =
+          (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
+      assertThat(output, is(notNullValue()));
+      assertThat(output.hasIssue(), is(true));
+      // empty profiles for Patient and Encounter has 2 issues, required profile missing adds
+      // another one
+      assertThat(output.getIssue().size(), is(equalTo(2)));
+    }
   }
 
   @Test
@@ -93,16 +81,18 @@ class ResourceValidationServiceTest {
     p.getMeta().addProfile(UriConstants.QiCore.PATIENT_PROFILE_URI);
     Encounter encounter = new Encounter();
     encounter.getMeta().addProfile("invalidURL");
-    bundleUtilMock
-        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-        .thenReturn(List.of(p, encounter));
+    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
+      utilities
+          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+          .thenReturn(List.of(p, encounter));
 
-    Bundle bundle = new Bundle();
-    OperationOutcome output =
-        (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
-    assertThat(output, is(notNullValue()));
-    assertThat(output.hasIssue(), is(true));
-    assertThat(output.getIssue().size(), is(equalTo(1)));
+      Bundle bundle = new Bundle();
+      OperationOutcome output =
+          (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
+      assertThat(output, is(notNullValue()));
+      assertThat(output.hasIssue(), is(true));
+      assertThat(output.getIssue().size(), is(equalTo(1)));
+    }
   }
 
   @Test
@@ -111,16 +101,18 @@ class ResourceValidationServiceTest {
     p.getMeta().addProfile(UriConstants.QiCore.PATIENT_PROFILE_URI);
     Encounter encounter = new Encounter();
     encounter.getMeta().addProfile("http://localhost:8080/measures/id?s=^IXIC");
-    bundleUtilMock
-        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-        .thenReturn(List.of(p, encounter));
+    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
+      utilities
+          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+          .thenReturn(List.of(p, encounter));
 
-    Bundle bundle = new Bundle();
-    OperationOutcome output =
-        (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
-    assertThat(output, is(notNullValue()));
-    assertThat(output.hasIssue(), is(true));
-    assertThat(output.getIssue().size(), is(equalTo(1)));
+      Bundle bundle = new Bundle();
+      OperationOutcome output =
+          (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
+      assertThat(output, is(notNullValue()));
+      assertThat(output.hasIssue(), is(true));
+      assertThat(output.getIssue().size(), is(equalTo(1)));
+    }
   }
 
   @Test
@@ -129,15 +121,17 @@ class ResourceValidationServiceTest {
     p.getMeta().addProfile(UriConstants.QiCore.PATIENT_PROFILE_URI);
     Encounter encounter = new Encounter();
     encounter.getMeta().addProfile("http://test.profile.com");
-    bundleUtilMock
-        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-        .thenReturn(List.of(p, encounter));
+    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
+      utilities
+          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+          .thenReturn(List.of(p, encounter));
 
-    Bundle bundle = new Bundle();
-    OperationOutcome output =
-        (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
-    assertThat(output, is(notNullValue()));
-    assertThat(output.hasIssue(), is(false));
+      Bundle bundle = new Bundle();
+      OperationOutcome output =
+          (OperationOutcome) validationService.validateBundleResourcesProfiles(fhirContext, bundle);
+      assertThat(output, is(notNullValue()));
+      assertThat(output.hasIssue(), is(false));
+    }
   }
 
   @Test
@@ -148,16 +142,18 @@ class ResourceValidationServiceTest {
     e1.setId("1234");
     Encounter e2 = new Encounter();
     e2.setId("1234");
-    bundleUtilMock
-        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-        .thenReturn(List.of(p, e1, e2));
+    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
+      utilities
+          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+          .thenReturn(List.of(p, e1, e2));
 
-    Bundle bundle = new Bundle();
-    OperationOutcome output =
-        (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
-    assertThat(output, is(notNullValue()));
-    assertThat(output.hasIssue(), is(true));
-    assertThat(output.getIssueFirstRep().getDiagnostics().contains("1234"), is(true));
+      Bundle bundle = new Bundle();
+      OperationOutcome output =
+          (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
+      assertThat(output, is(notNullValue()));
+      assertThat(output.hasIssue(), is(true));
+      assertThat(output.getIssueFirstRep().getDiagnostics().contains("1234"), is(true));
+    }
   }
 
   @Test
@@ -170,17 +166,19 @@ class ResourceValidationServiceTest {
     p1.setId("1234");
     Encounter e2 = new Encounter();
     e2.setId("3456");
-    bundleUtilMock
-        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-        .thenReturn(List.of(p, e1, p1, e2));
+    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
+      utilities
+          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+          .thenReturn(List.of(p, e1, p1, e2));
 
-    Bundle bundle = new Bundle();
-    OperationOutcome output =
-        (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
-    assertThat(output, is(notNullValue()));
-    assertThat(output.hasIssue(), is(true));
-    assertThat(output.getIssueFirstRep().getDiagnostics().contains("1234"), is(true));
-    assertThat(output.getIssue().size(), is(equalTo(1)));
+      Bundle bundle = new Bundle();
+      OperationOutcome output =
+          (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
+      assertThat(output, is(notNullValue()));
+      assertThat(output.hasIssue(), is(true));
+      assertThat(output.getIssueFirstRep().getDiagnostics().contains("1234"), is(true));
+      assertThat(output.getIssue().size(), is(equalTo(1)));
+    }
   }
 
   @Test
@@ -191,15 +189,17 @@ class ResourceValidationServiceTest {
     e1.setId("2222");
     Encounter e2 = new Encounter();
     e2.setId("3333");
-    bundleUtilMock
-        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-        .thenReturn(List.of(p, e1, e2));
+    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
+      utilities
+          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+          .thenReturn(List.of(p, e1, e2));
 
-    Bundle bundle = new Bundle();
-    OperationOutcome output =
-        (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
-    assertThat(output, is(notNullValue()));
-    assertThat(output.hasIssue(), is(false));
+      Bundle bundle = new Bundle();
+      OperationOutcome output =
+          (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
+      assertThat(output, is(notNullValue()));
+      assertThat(output.hasIssue(), is(false));
+    }
   }
 
   @Test
@@ -209,16 +209,18 @@ class ResourceValidationServiceTest {
     e1.setId("2222");
     Encounter e2 = new Encounter();
     e2.setId("3333");
-    bundleUtilMock
-        .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
-        .thenReturn(List.of(p, e1, e2));
+    try (MockedStatic<BundleUtil> utilities = Mockito.mockStatic(BundleUtil.class)) {
+      utilities
+          .when(() -> BundleUtil.toListOfResources(any(FhirContext.class), any(IBaseBundle.class)))
+          .thenReturn(List.of(p, e1, e2));
 
-    Bundle bundle = new Bundle();
-    OperationOutcome output =
-        (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
-    assertThat(output, is(notNullValue()));
-    assertThat(output.hasIssue(), is(true));
-    assertEquals("All resources must have an Id", output.getIssueFirstRep().getDiagnostics());
+      Bundle bundle = new Bundle();
+      OperationOutcome output =
+          (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
+      assertThat(output, is(notNullValue()));
+      assertThat(output.hasIssue(), is(true));
+      assertEquals(output.getIssueFirstRep().getDiagnostics(), "All resources must have an Id");
+    }
   }
 
   @Test

--- a/src/test/java/gov/cms/madie/madiefhirservice/validators/CustomRemoteTerminologyServiceValidationSupportTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/validators/CustomRemoteTerminologyServiceValidationSupportTest.java
@@ -586,14 +586,11 @@ class CustomRemoteTerminologyServiceValidationSupportTest {
     when(query.execute()).thenReturn(bundle);
 
     List<IBaseResource> mockResources = List.of(codeSystemResource);
-    // Ensure static mock is closed after use to avoid leaking into other tests
-    try (MockedStatic<BundleUtil> bundleUtilMock = mockStatic(BundleUtil.class)) {
-      bundleUtilMock
-          .when(() -> BundleUtil.toListOfResources(fhirContext, bundle))
-          .thenReturn(mockResources);
+    mockStatic(BundleUtil.class);
+    when(BundleUtil.toListOfResources(fhirContext, bundle)).thenReturn(mockResources);
 
-      IBaseResource result = validationSupport.fetchValueSet(validCtsUrl);
-      assertThat(result, is(codeSystemResource));
-    }
+    IBaseResource result = validationSupport.fetchValueSet(validCtsUrl);
+
+    assertThat(result, is(codeSystemResource));
   }
 }

--- a/src/test/java/gov/cms/madie/madiefhirservice/validators/CustomRemoteTerminologyServiceValidationSupportTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/validators/CustomRemoteTerminologyServiceValidationSupportTest.java
@@ -586,10 +586,16 @@ class CustomRemoteTerminologyServiceValidationSupportTest {
     when(query.execute()).thenReturn(bundle);
 
     List<IBaseResource> mockResources = List.of(codeSystemResource);
-    when(BundleUtil.toListOfResources(fhirContext, bundle)).thenReturn(mockResources);
+    try (MockedStatic<BundleUtil> bundleUtilMock = mockStatic(BundleUtil.class)) {
+      bundleUtilMock
+          .when(() -> BundleUtil.toListOfResources(fhirContext, bundle))
+          .thenReturn(mockResources);
 
-    IBaseResource result = validationSupport.fetchValueSet(validCtsUrl);
+      // when
+      IBaseResource result = validationSupport.fetchValueSet(validCtsUrl);
 
-    assertThat(result, is(codeSystemResource));
+      // then
+      assertThat(result, is(codeSystemResource));
+    }
   }
 }

--- a/src/test/java/gov/cms/madie/madiefhirservice/validators/CustomRemoteTerminologyServiceValidationSupportTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/validators/CustomRemoteTerminologyServiceValidationSupportTest.java
@@ -586,7 +586,6 @@ class CustomRemoteTerminologyServiceValidationSupportTest {
     when(query.execute()).thenReturn(bundle);
 
     List<IBaseResource> mockResources = List.of(codeSystemResource);
-    mockStatic(BundleUtil.class);
     when(BundleUtil.toListOfResources(fhirContext, bundle)).thenReturn(mockResources);
 
     IBaseResource result = validationSupport.fetchValueSet(validCtsUrl);


### PR DESCRIPTION
…

## MADiE FHIR SERVICE

Jira Ticket: [MAT-9115](https://jira.cms.gov/browse/MAT-9115)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
