### PR TITLE
MAT-9451 update HAPI FHIR version to v8.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,12 @@
 			<version>${hapi.fhir.r4.version}</version>
 		</dependency>
 
+		<!-- In-memory caching - required in HAPI FHIR v7.4.3 -->
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-caching-caffeine</artifactId>
+			<version>${hapi.fhir.r4.version}</version>
+		</dependency>
 
 		<!-- required cqframework dependencies -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 		<dependency>
 			<groupId>gov.cms.madie</groupId>
 			<artifactId>madie-rest-commons</artifactId>
-			<version>1.0.3-SNAPSHOT</version>
+			<version>1.0.5-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.okta.spring</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
 		<dependency>
 			<groupId>gov.cms.madie.packaging</groupId>
 			<artifactId>packaging-utility</artifactId>
-			<version>0.2.12-SNAPSHOT</version>
+			<version>0.2.13-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>gov.cms.madie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 		<dependency>
 			<groupId>gov.cms.madie</groupId>
 			<artifactId>madie-rest-commons</artifactId>
-			<version>1.0.1-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.okta.spring</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<springfox.version>3.0.0</springfox.version>
-		 <hapi.fhir.r4.version>8.4.0</hapi.fhir.r4.version>
+		 <hapi.fhir.r4.version>8.6.1</hapi.fhir.r4.version>
 		<cqframework.version>3.29.0</cqframework.version>
 		<org.fhir.ucum.version>1.0.9</org.fhir.ucum.version>
 	</properties>
@@ -37,12 +37,6 @@
 
 	<dependencyManagement>
 		<dependencies>
-			<!-- override thymeleaf dependency for hapi-fhir because there is a critical vulnerability -->
-			<dependency>
-				<groupId>org.thymeleaf</groupId>
-				<artifactId>thymeleaf</artifactId>
-				<version>3.1.2.RELEASE</version>
-			</dependency>
 			<dependency>
 				<groupId>org.fhir</groupId>
 				<artifactId>ucum</artifactId>
@@ -119,12 +113,6 @@
 			<version>${hapi.fhir.r4.version}</version>
 		</dependency>
 
-		<!-- In-memory caching - required in HAPI FHIR v7.4.3 -->
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-caching-caffeine</artifactId>
-			<version>${hapi.fhir.r4.version}</version>
-		</dependency>
 
 		<!-- required cqframework dependencies -->
 		<dependency>

--- a/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
@@ -99,11 +99,6 @@ public class HapiFhirConfig {
         buildPrePopulatedValidationSupportFromZip(
             qicore6FhirContext, "classpath:packages/tx-qicore-6.0.0.zip");
 
-    UnknownCodeSystemWarningValidationSupport unknownCodeSystemWarningValidationSupport =
-        new UnknownCodeSystemWarningValidationSupport(qicore6FhirContext);
-    unknownCodeSystemWarningValidationSupport.setNonExistentCodeSystemSeverity(
-        IValidationSupport.IssueSeverity.WARNING);
-
     RemoteTerminologyServiceValidationSupport remoteTerminologyServiceValidationSupport =
         getRemoteTerminologyServiceValidationSupport(qicore6FhirContext);
     return new ValidationSupportChain(
@@ -112,8 +107,7 @@ public class HapiFhirConfig {
         new DefaultProfileValidationSupport(qicore6FhirContext),
         new CustomQiCoreInMemoryValidationSupport(qicore6FhirContext, validationConfig),
         new CommonCodeSystemsTerminologyService(qicore6FhirContext),
-        remoteTerminologyServiceValidationSupport,
-        unknownCodeSystemWarningValidationSupport);
+        remoteTerminologyServiceValidationSupport);
   }
 
   public RemoteTerminologyServiceValidationSupport getRemoteTerminologyServiceValidationSupport(


### PR DESCRIPTION
### MAT-9451 update HAPI FHIR version to v8.6.1
- removed deprecated UnknownCodeSystemValidationSupport
- Removed unwanted direct dependencies from pom.xml
- Updated madie-rest-commons version

## MADiE FHIR SERVICE

Jira Ticket: [MAT-9451](https://jira.cms.gov/browse/MAT-9451)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
