### PR TITLE
MAT-9451 revert UnknownCodeSystemWarningValidationSupport change(depr…

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
@@ -99,15 +99,22 @@ public class HapiFhirConfig {
         buildPrePopulatedValidationSupportFromZip(
             qicore6FhirContext, "classpath:packages/tx-qicore-6.0.0.zip");
 
+    UnknownCodeSystemWarningValidationSupport unknownCodeSystemWarningValidationSupport =
+        new UnknownCodeSystemWarningValidationSupport(qicore6FhirContext);
+    unknownCodeSystemWarningValidationSupport.setNonExistentCodeSystemSeverity(
+        IValidationSupport.IssueSeverity.WARNING);
+
     RemoteTerminologyServiceValidationSupport remoteTerminologyServiceValidationSupport =
         getRemoteTerminologyServiceValidationSupport(qicore6FhirContext);
+
     return new ValidationSupportChain(
         prePopulatedValidationSupport,
         npmPackageSupport,
         new DefaultProfileValidationSupport(qicore6FhirContext),
         new CustomQiCoreInMemoryValidationSupport(qicore6FhirContext, validationConfig),
         new CommonCodeSystemsTerminologyService(qicore6FhirContext),
-        remoteTerminologyServiceValidationSupport);
+        remoteTerminologyServiceValidationSupport,
+        unknownCodeSystemWarningValidationSupport);
   }
 
   public RemoteTerminologyServiceValidationSupport getRemoteTerminologyServiceValidationSupport(


### PR DESCRIPTION
MAT-9451 reverted UnknownCodeSystemWarningValidationSupport. This is deprecated in HAPI FHIR v8. We will have to implement the recommended fix later. https://hapifhir.io/hapi-fhir/docs/validation/validation_support_modules.html#unknowncodesystemwarningvalidationsupport

## MADiE FHIR SERVICE

Jira Ticket: [MAT-9451](https://jira.cms.gov/browse/MAT-9451)
(Optional) Related Tickets:

### Summary

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
