### PR TITLE
MAT-9563: Exclude Empty Population/Strat Expected Values from MeasureReport

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/services/TestCaseBundleService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/TestCaseBundleService.java
@@ -332,13 +332,19 @@ public class TestCaseBundleService {
 
   private MeasureReport.MeasureReportGroupPopulationComponent
       getMeasureReportGroupPopulationComponent(TestCasePopulationValue testCasePopulationValue) {
-    return (new MeasureReport.MeasureReportGroupPopulationComponent())
-        .setCode(
-            FhirResourceHelpers.buildCodeableConcept(
-                getPopulationType(testCasePopulationValue.getName()).toCode(),
-                UriConstants.CodeSystem.POPULATION_SYSTEM_URI,
-                getPopulationType(testCasePopulationValue.getName()).getDisplay()))
-        .setCount(FhirResourceHelpers.getExpectedValue(testCasePopulationValue.getExpected()));
+    var groupPopComponent =
+        new MeasureReport.MeasureReportGroupPopulationComponent()
+            .setCode(
+                FhirResourceHelpers.buildCodeableConcept(
+                    getPopulationType(testCasePopulationValue.getName()).toCode(),
+                    UriConstants.CodeSystem.POPULATION_SYSTEM_URI,
+                    getPopulationType(testCasePopulationValue.getName()).getDisplay()));
+    // Exclude the count attribute when Expected Value is empty
+    if (FhirResourceHelpers.getExpectedValue(testCasePopulationValue.getExpected()) >= 0) {
+      groupPopComponent.setCount(
+          FhirResourceHelpers.getExpectedValue(testCasePopulationValue.getExpected()));
+    }
+    return groupPopComponent;
   }
 
   // MAT-8349: Denominator and Numerator Observations are not part of measure report population

--- a/src/main/java/gov/cms/madie/madiefhirservice/utils/FhirResourceHelpers.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/utils/FhirResourceHelpers.java
@@ -75,7 +75,7 @@ public class FhirResourceHelpers {
    */
   public static int getExpectedValue(Object expectedValue) {
     if (expectedValue == null || StringUtils.isBlank(expectedValue.toString())) {
-      return 0;
+      return -1; // To be excluded
     } else if (expectedValue instanceof Boolean) {
       return (Boolean) expectedValue ? 1 : 0;
     } else {
@@ -111,16 +111,20 @@ public class FhirResourceHelpers {
                           UriConstants.CodeSystem.POPULATION_SYSTEM_URI,
                           populationValue.getName().getDisplay()));
 
-                  stratifierGroupPopulationComponent.setCount(
-                      isPatientBased
-                          ? (valueIndex
+                  // Exclude the count attribute when Expected Value is empty
+                  if (getExpectedValue(populationValue.getExpected()) >= 0) {
+                    if (isPatientBased) {
+                      stratifierGroupPopulationComponent.setCount(
+                          valueIndex
                               ? getExpectedValue(populationValue.getExpected())
                               : getExpectedInverseValue(
-                                  getExpectedValue(populationValue.getExpected())))
-                          : (populationValue.getExpected() == null
-                                  || populationValue.getExpected().toString().isEmpty()
-                              ? 0 // Convert empty expected values to 0
-                              : Integer.parseInt(populationValue.getExpected().toString())));
+                                  getExpectedValue(populationValue.getExpected())));
+                    } else {
+                      stratifierGroupPopulationComponent.setCount(
+                          Integer.parseInt(populationValue.getExpected().toString()));
+                    }
+                  }
+
                   return stratifierGroupPopulationComponent;
                 })
             .collect(Collectors.toList());

--- a/src/main/java/gov/cms/madie/madiefhirservice/utils/FhirResourceHelpers.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/utils/FhirResourceHelpers.java
@@ -117,7 +117,10 @@ public class FhirResourceHelpers {
                               ? getExpectedValue(populationValue.getExpected())
                               : getExpectedInverseValue(
                                   getExpectedValue(populationValue.getExpected())))
-                          : Integer.parseInt(populationValue.getExpected().toString()));
+                          : (populationValue.getExpected() == null
+                                  || populationValue.getExpected().toString().isEmpty()
+                              ? 0 // Convert empty expected values to 0
+                              : Integer.parseInt(populationValue.getExpected().toString())));
                   return stratifierGroupPopulationComponent;
                 })
             .collect(Collectors.toList());

--- a/src/test/java/gov/cms/madie/madiefhirservice/utils/FhirResourceHelpersTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/utils/FhirResourceHelpersTest.java
@@ -66,7 +66,7 @@ public class FhirResourceHelpersTest {
   }
 
   @Test
-  void testexpectedInverseValue() {
+  void testExpectedInverseValue() {
     assertEquals(1, FhirResourceHelpers.getExpectedInverseValue(0));
     assertEquals(0, FhirResourceHelpers.getExpectedInverseValue(1));
   }
@@ -106,19 +106,19 @@ public class FhirResourceHelpersTest {
     List<MeasureReport.StratifierGroupPopulationComponent> stratifierGroupPopulationComponents =
         FhirResourceHelpers.buildStratumPopulation(stratValue1, true, true, group1);
 
-    assertEquals(stratifierGroupPopulationComponents.size(), 3);
-    assertEquals(
+    assertThat(stratifierGroupPopulationComponents.size(), is(3));
+    assertThat(
         stratifierGroupPopulationComponents.get(0).getCode().getCoding().get(0).getCode(),
-        "initial-population");
-    assertEquals(stratifierGroupPopulationComponents.get(0).getCount(), 1);
-    assertEquals(
+        is("initial-population"));
+    assertThat(stratifierGroupPopulationComponents.get(0).getCount(), is(1));
+    assertThat(
         stratifierGroupPopulationComponents.get(1).getCode().getCoding().get(0).getCode(),
-        "denominator");
-    assertEquals(stratifierGroupPopulationComponents.get(1).getCount(), 1);
-    assertEquals(
+        is("denominator"));
+    assertThat(stratifierGroupPopulationComponents.get(1).getCount(), is(1));
+    assertThat(
         stratifierGroupPopulationComponents.get(2).getCode().getCoding().get(0).getCode(),
-        "numerator");
-    assertEquals(stratifierGroupPopulationComponents.get(2).getCount(), 0);
+        is("numerator"));
+    assertThat(stratifierGroupPopulationComponents.get(2).getCount(), is(0));
 
     assertEquals("InitialPopulation_1", stratifierGroupPopulationComponents.get(0).getId());
     assertEquals("Denominator_1", stratifierGroupPopulationComponents.get(1).getId());
@@ -160,19 +160,19 @@ public class FhirResourceHelpersTest {
     List<MeasureReport.StratifierGroupPopulationComponent> stratifierGroupPopulationComponents =
         FhirResourceHelpers.buildStratumPopulation(stratValue1, false, true, group1);
 
-    assertEquals(stratifierGroupPopulationComponents.size(), 3);
-    assertEquals(
+    assertThat(stratifierGroupPopulationComponents.size(), is(3));
+    assertThat(
         stratifierGroupPopulationComponents.get(0).getCode().getCoding().get(0).getCode(),
-        "initial-population");
-    assertEquals(stratifierGroupPopulationComponents.get(0).getCount(), 0);
-    assertEquals(
+        is("initial-population"));
+    assertThat(stratifierGroupPopulationComponents.get(0).getCount(), is(0));
+    assertThat(
         stratifierGroupPopulationComponents.get(1).getCode().getCoding().get(0).getCode(),
-        "denominator");
-    assertEquals(stratifierGroupPopulationComponents.get(1).getCount(), 0);
-    assertEquals(
+        is("denominator"));
+    assertThat(stratifierGroupPopulationComponents.get(1).getCount(), is(0));
+    assertThat(
         stratifierGroupPopulationComponents.get(2).getCode().getCoding().get(0).getCode(),
-        "numerator");
-    assertEquals(stratifierGroupPopulationComponents.get(2).getCount(), 1);
+        is("numerator"));
+    assertThat(stratifierGroupPopulationComponents.get(2).getCount(), is(1));
 
     assertEquals("InitialPopulation_1", stratifierGroupPopulationComponents.get(0).getId());
     assertEquals("Denominator_1", stratifierGroupPopulationComponents.get(1).getId());
@@ -214,19 +214,19 @@ public class FhirResourceHelpersTest {
     List<MeasureReport.StratifierGroupPopulationComponent> stratifierGroupPopulationComponents =
         FhirResourceHelpers.buildStratumPopulation(stratValue1, null, false, group1);
 
-    assertEquals(stratifierGroupPopulationComponents.size(), 3);
-    assertEquals(
+    assertThat(stratifierGroupPopulationComponents.size(), is(3));
+    assertThat(
         stratifierGroupPopulationComponents.get(0).getCode().getCoding().get(0).getCode(),
-        "initial-population");
-    assertEquals(stratifierGroupPopulationComponents.get(0).getCount(), 5);
-    assertEquals(
+        is("initial-population"));
+    assertThat(stratifierGroupPopulationComponents.get(0).getCount(), is(5));
+    assertThat(
         stratifierGroupPopulationComponents.get(1).getCode().getCoding().get(0).getCode(),
-        "denominator");
-    assertEquals(stratifierGroupPopulationComponents.get(1).getCount(), 4);
-    assertEquals(
+        is("denominator"));
+    assertThat(stratifierGroupPopulationComponents.get(1).getCount(), is(4));
+    assertThat(
         stratifierGroupPopulationComponents.get(2).getCode().getCoding().get(0).getCode(),
-        "numerator");
-    assertEquals(stratifierGroupPopulationComponents.get(2).getCount(), 2);
+        is("numerator"));
+    assertThat(stratifierGroupPopulationComponents.get(2).getCount(), is(2));
 
     assertEquals("InitialPopulation_1", stratifierGroupPopulationComponents.get(0).getId());
     assertEquals("Denominator_1", stratifierGroupPopulationComponents.get(1).getId());

--- a/src/test/java/gov/cms/madie/madiefhirservice/utils/FhirResourceHelpersTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/utils/FhirResourceHelpersTest.java
@@ -234,6 +234,60 @@ public class FhirResourceHelpersTest {
   }
 
   @Test
+  void testBuildStratumPopulationForNonPatientBasedMeasuresWithEmptyExpectedValues() {
+    TestCaseStratificationValue stratValue1 =
+        TestCaseStratificationValue.builder().name("Strata-1").id("strat1Id").expected(1).build();
+    stratValue1.setPopulationValues(
+        List.of(
+            TestCasePopulationValue.builder()
+                .id("1")
+                .name(PopulationType.INITIAL_POPULATION)
+                .expected(null)
+                .build(),
+            TestCasePopulationValue.builder()
+                .id("2")
+                .name(PopulationType.DENOMINATOR)
+                .expected("")
+                .build(),
+            TestCasePopulationValue.builder()
+                .id("3")
+                .name(PopulationType.NUMERATOR)
+                .expected(1)
+                .build()));
+
+    Population pop1 = Population.builder().id("1").displayId("InitialPopulation_1").build();
+    Population pop2 = Population.builder().id("2").displayId("Denominator_1").build();
+    Population pop3 = Population.builder().id("3").displayId("Numerator_1").build();
+    Group group1 =
+        Group.builder()
+            .id("group1Id")
+            .displayId("Group_1")
+            .populations(List.of(pop1, pop2, pop3))
+            .build();
+
+    List<MeasureReport.StratifierGroupPopulationComponent> stratifierGroupPopulationComponents =
+        FhirResourceHelpers.buildStratumPopulation(stratValue1, null, false, group1);
+
+    assertEquals(3, stratifierGroupPopulationComponents.size());
+    assertEquals(
+        "initial-population",
+        stratifierGroupPopulationComponents.get(0).getCode().getCoding().get(0).getCode());
+    assertEquals(0, stratifierGroupPopulationComponents.get(0).getCount());
+    assertEquals(
+        "denominator",
+        stratifierGroupPopulationComponents.get(1).getCode().getCoding().get(0).getCode());
+    assertEquals(0, stratifierGroupPopulationComponents.get(1).getCount());
+    assertEquals(
+        "numerator",
+        stratifierGroupPopulationComponents.get(2).getCode().getCoding().get(0).getCode());
+    assertEquals(1, stratifierGroupPopulationComponents.get(2).getCount());
+
+    assertEquals("InitialPopulation_1", stratifierGroupPopulationComponents.get(0).getId());
+    assertEquals("Denominator_1", stratifierGroupPopulationComponents.get(1).getId());
+    assertEquals("Numerator_1", stratifierGroupPopulationComponents.get(2).getId());
+  }
+
+  @Test
   void testGetGroupStratificationDisplayIdPopulationsNotFound() {
     Group group1 =
         Group.builder()

--- a/src/test/java/gov/cms/madie/madiefhirservice/utils/FhirResourceHelpersTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/utils/FhirResourceHelpersTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class FhirResourceHelpersTest {
 
@@ -272,11 +273,11 @@ public class FhirResourceHelpersTest {
     assertEquals(
         "initial-population",
         stratifierGroupPopulationComponents.get(0).getCode().getCoding().get(0).getCode());
-    assertEquals(0, stratifierGroupPopulationComponents.get(0).getCount());
+    assertNull(stratifierGroupPopulationComponents.get(0).getCountElement().getValue());
     assertEquals(
         "denominator",
         stratifierGroupPopulationComponents.get(1).getCode().getCoding().get(0).getCode());
-    assertEquals(0, stratifierGroupPopulationComponents.get(1).getCount());
+    assertNull(stratifierGroupPopulationComponents.get(1).getCountElement().getValue());
     assertEquals(
         "numerator",
         stratifierGroupPopulationComponents.get(2).getCode().getCoding().get(0).getCode());


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-9563](https://jira.cms.gov/browse/MAT-9563)
(Optional) Related Tickets:

### Summary

> For optional elements, preference is not to provide the element. If the element is required, there is a data-absent-reason extension. -SME

Excludes the `count` attribute in the MeasureReport whenever the incoming Expected Value is empty or null.

~~Convert empty or null Stratification expected values to 0. This satisfies the FHIR integer type expected for the count attribute. Also, it prevents the TC export from breaking due to failure to convert null and empty strings to int.~~

Unit test editorial fixes. Since the expected/actual arguments were swapped, switched assertEquals to assertThat to maintain existing order.


### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
