### PR TITLE
MAT-9536 custom validation support for unknown code systems

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.validation.IValidatorModule;
 import gov.cms.madie.madiefhirservice.utils.ResourceUtils;
 import gov.cms.madie.madiefhirservice.validators.CustomQiCoreInMemoryValidationSupport;
 import gov.cms.madie.madiefhirservice.validators.CustomRemoteTerminologyServiceValidationSupport;
+import gov.cms.madie.madiefhirservice.validators.CustomUnknownCodeSystemWarningValidationSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.common.hapi.validation.support.*;
 import org.hl7.fhir.common.hapi.validation.validator.FhirInstanceValidator;
@@ -71,10 +72,8 @@ public class HapiFhirConfig {
     npmPackageSupport.loadPackageFromClasspath(
         "classpath:packages/hl7.fhir.xver-extensions-0.0.13.tgz");
 
-    UnknownCodeSystemWarningValidationSupport unknownCodeSystemWarningValidationSupport =
-        new UnknownCodeSystemWarningValidationSupport(qicoreFhirContext);
-    unknownCodeSystemWarningValidationSupport.setNonExistentCodeSystemSeverity(
-        IValidationSupport.IssueSeverity.WARNING);
+    CustomUnknownCodeSystemWarningValidationSupport unknownCodeSystemWarningValidationSupport =
+        getUnknownCodeSystemValidationSupport(qicoreFhirContext);
 
     return new ValidationSupportChain(
         npmPackageSupport,
@@ -99,10 +98,8 @@ public class HapiFhirConfig {
         buildPrePopulatedValidationSupportFromZip(
             qicore6FhirContext, "classpath:packages/tx-qicore-6.0.0.zip");
 
-    UnknownCodeSystemWarningValidationSupport unknownCodeSystemWarningValidationSupport =
-        new UnknownCodeSystemWarningValidationSupport(qicore6FhirContext);
-    unknownCodeSystemWarningValidationSupport.setNonExistentCodeSystemSeverity(
-        IValidationSupport.IssueSeverity.WARNING);
+    CustomUnknownCodeSystemWarningValidationSupport unknownCodeSystemWarningValidationSupport =
+        getUnknownCodeSystemValidationSupport(qicore6FhirContext);
 
     RemoteTerminologyServiceValidationSupport remoteTerminologyServiceValidationSupport =
         getRemoteTerminologyServiceValidationSupport(qicore6FhirContext);
@@ -124,6 +121,15 @@ public class HapiFhirConfig {
         terminologyServerBase,
         new BasicAuthInterceptor("apikey", vsacApiKey),
         validationConfig);
+  }
+
+  public CustomUnknownCodeSystemWarningValidationSupport getUnknownCodeSystemValidationSupport(
+      FhirContext qicore6FhirContext) {
+    var unknownCodeSystemSupportChain =
+        new CustomUnknownCodeSystemWarningValidationSupport(qicore6FhirContext);
+    unknownCodeSystemSupportChain.setNonExistentCodeSystemSeverity(
+        IValidationSupport.IssueSeverity.WARNING);
+    return unknownCodeSystemSupportChain;
   }
 
   @Bean

--- a/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/config/HapiFhirConfig.java
@@ -114,7 +114,7 @@ public class HapiFhirConfig {
         unknownCodeSystemWarningValidationSupport);
   }
 
-  public RemoteTerminologyServiceValidationSupport getRemoteTerminologyServiceValidationSupport(
+  private RemoteTerminologyServiceValidationSupport getRemoteTerminologyServiceValidationSupport(
       FhirContext qicore6FhirContext) {
     return new CustomRemoteTerminologyServiceValidationSupport(
         qicore6FhirContext,
@@ -123,7 +123,7 @@ public class HapiFhirConfig {
         validationConfig);
   }
 
-  public CustomUnknownCodeSystemWarningValidationSupport getUnknownCodeSystemValidationSupport(
+  private CustomUnknownCodeSystemWarningValidationSupport getUnknownCodeSystemValidationSupport(
       FhirContext qicore6FhirContext) {
     var unknownCodeSystemSupportChain =
         new CustomUnknownCodeSystemWarningValidationSupport(qicore6FhirContext);

--- a/src/main/java/gov/cms/madie/madiefhirservice/validators/CustomUnknownCodeSystemWarningValidationSupport.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/validators/CustomUnknownCodeSystemWarningValidationSupport.java
@@ -164,10 +164,7 @@ public class CustomUnknownCodeSystemWarningValidationSupport extends BaseValidat
     }
     IBaseResource codeSystem =
         theValidationSupportContext.getRootValidationSupport().fetchCodeSystem(theCodeSystem);
-    if (codeSystem != null) {
-      return false;
-    }
-    return true;
+    return codeSystem == null;
   }
 
   /**

--- a/src/main/java/gov/cms/madie/madiefhirservice/validators/CustomUnknownCodeSystemWarningValidationSupport.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/validators/CustomUnknownCodeSystemWarningValidationSupport.java
@@ -1,0 +1,190 @@
+package gov.cms.madie.madiefhirservice.validators;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.support.ConceptValidationOptions;
+import ca.uhn.fhir.context.support.LookupCodeRequest;
+import ca.uhn.fhir.context.support.ValidationSupportContext;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.Validate;
+import org.hl7.fhir.common.hapi.validation.support.BaseValidationSupport;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+/**
+ * This custom validation support module to be placed at the end of a validation support chain in
+ * order to configure the validator to generate a warning if a resource being validated contains an
+ * unknown code system. This class is a copy of the HAPI FHIR
+ * UnknownCodeSystemWarningValidationSupport chain as HAPI has deprecated it
+ */
+@Slf4j
+public class CustomUnknownCodeSystemWarningValidationSupport extends BaseValidationSupport {
+
+  public static final IssueSeverity DEFAULT_SEVERITY = IssueSeverity.ERROR;
+
+  private IssueSeverity myNonExistentCodeSystemSeverity = DEFAULT_SEVERITY;
+
+  public CustomUnknownCodeSystemWarningValidationSupport(FhirContext theFhirContext) {
+    super(theFhirContext);
+  }
+
+  @Override
+  public String getName() {
+    return getFhirContext().getVersion().getVersion()
+        + " Unknown Code System Warning Validation Support";
+  }
+
+  @Override
+  public boolean isValueSetSupported(
+      ValidationSupportContext theValidationSupportContext, String theValueSetUrl) {
+    return true;
+  }
+
+  @Override
+  public boolean isCodeSystemSupported(
+      ValidationSupportContext theValidationSupportContext, String theSystem) {
+    return canValidateCodeSystem(theValidationSupportContext, theSystem);
+  }
+
+  @Nullable
+  @Override
+  public LookupCodeResult lookupCode(
+      ValidationSupportContext theValidationSupportContext,
+      @Nonnull LookupCodeRequest theLookupCodeRequest) {
+    // filters out error/fatal
+    if (canValidateCodeSystem(theValidationSupportContext, theLookupCodeRequest.getSystem())) {
+      return new LookupCodeResult().setFound(true);
+    }
+
+    return null;
+  }
+
+  @Override
+  public CodeValidationResult validateCode(
+      @Nonnull ValidationSupportContext theValidationSupportContext,
+      @Nonnull ConceptValidationOptions theOptions,
+      String theCodeSystem,
+      String theCode,
+      String theDisplay,
+      String theValueSetUrl) {
+    // filters out error/fatal
+    if (!canValidateCodeSystem(theValidationSupportContext, theCodeSystem)) {
+      return null;
+    }
+
+    CodeValidationResult result = new CodeValidationResult();
+    // will be warning or info (error/fatal filtered out above)
+    result.setSeverity(myNonExistentCodeSystemSeverity);
+    String theMessage =
+        "CodeSystem is unknown and can't be validated: "
+            + theCodeSystem
+            + " for '"
+            + theCodeSystem
+            + "#"
+            + theCode
+            + "'";
+    result.setMessage(theMessage);
+
+    // For information level, we just strip out the severity+message entirely
+    // so that nothing appears in the validation result
+    if (myNonExistentCodeSystemSeverity == IssueSeverity.INFORMATION) {
+      result.setCode(theCode);
+      result.setSeverity(null);
+      result.setMessage(null);
+    } else {
+      result.addIssue(
+          new CodeValidationIssue(
+              theMessage,
+              myNonExistentCodeSystemSeverity,
+              CodeValidationIssueCode.NOT_FOUND,
+              CodeValidationIssueCoding.NOT_FOUND));
+    }
+
+    return result;
+  }
+
+  @Nullable
+  @Override
+  public CodeValidationResult validateCodeInValueSet(
+      ValidationSupportContext theValidationSupportContext,
+      ConceptValidationOptions theOptions,
+      String theCodeSystem,
+      String theCode,
+      String theDisplay,
+      @Nonnull IBaseResource theValueSet) {
+    if (!canValidateCodeSystem(theValidationSupportContext, theCodeSystem)) {
+      return null;
+    }
+
+    return new CodeValidationResult()
+        .setCode(theCode)
+        .setSeverity(IssueSeverity.INFORMATION)
+        .setMessage(
+            "Code "
+                + theCodeSystem
+                + "#"
+                + theCode
+                + " was not checked because the CodeSystem is not available");
+  }
+
+  /**
+   * Returns true if non-existent code systems will still validate. False if they will throw errors.
+   */
+  private boolean allowNonExistentCodeSystems() {
+    switch (myNonExistentCodeSystemSeverity) {
+      case ERROR:
+      case FATAL:
+        return false;
+      case WARNING:
+      case INFORMATION:
+        return true;
+      default:
+        log.info(
+            "Unknown issue severity "
+                + myNonExistentCodeSystemSeverity.name()
+                + ". Treating as INFO/WARNING");
+        return true;
+    }
+  }
+
+  /**
+   * Determines if the code system can (and should) be validated.
+   *
+   * @param theValidationSupportContext
+   * @param theCodeSystem
+   * @return
+   */
+  private boolean canValidateCodeSystem(
+      ValidationSupportContext theValidationSupportContext, String theCodeSystem) {
+    if (!allowNonExistentCodeSystems()) {
+      return false;
+    }
+    if (theCodeSystem == null) {
+      return false;
+    }
+    IBaseResource codeSystem =
+        theValidationSupportContext.getRootValidationSupport().fetchCodeSystem(theCodeSystem);
+    if (codeSystem != null) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * If set to allow, code system violations will be flagged with Warning by default. Use
+   * setNonExistentCodeSystemSeverity instead.
+   */
+  public void setAllowNonExistentCodeSystem(boolean theAllowNonExistentCodeSystem) {
+    if (theAllowNonExistentCodeSystem) {
+      setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    } else {
+      setNonExistentCodeSystemSeverity(IssueSeverity.ERROR);
+    }
+  }
+
+  /** Sets the non-existent code system severity. */
+  public void setNonExistentCodeSystemSeverity(@Nonnull IssueSeverity theSeverity) {
+    Validate.notNull(theSeverity, "theSeverity must not be null");
+    myNonExistentCodeSystemSeverity = theSeverity;
+  }
+}

--- a/src/test/java/gov/cms/madie/madiefhirservice/validators/CustomUnknownCodeSystemWarningValidationSupportTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/validators/CustomUnknownCodeSystemWarningValidationSupportTest.java
@@ -49,7 +49,6 @@ class CustomUnknownCodeSystemWarningValidationSupportTest {
     assertThat(name, containsString("Unknown Code System Warning Validation Support"));
   }
 
-
   @Test
   void testIsValueSetSupportedAlwaysReturnsTrue() {
     boolean result =

--- a/src/test/java/gov/cms/madie/madiefhirservice/validators/CustomUnknownCodeSystemWarningValidationSupportTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/validators/CustomUnknownCodeSystemWarningValidationSupportTest.java
@@ -1,0 +1,428 @@
+package gov.cms.madie.madiefhirservice.validators;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.support.ConceptValidationOptions;
+import ca.uhn.fhir.context.support.IValidationSupport;
+import ca.uhn.fhir.context.support.IValidationSupport.CodeValidationResult;
+import ca.uhn.fhir.context.support.IValidationSupport.IssueSeverity;
+import ca.uhn.fhir.context.support.IValidationSupport.LookupCodeResult;
+import ca.uhn.fhir.context.support.LookupCodeRequest;
+import ca.uhn.fhir.context.support.ValidationSupportContext;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CustomUnknownCodeSystemWarningValidationSupportTest {
+
+  private CustomUnknownCodeSystemWarningValidationSupport validationSupport;
+  private FhirContext fhirContext;
+
+  @Mock private ValidationSupportContext validationSupportContext;
+  @Mock private IValidationSupport rootValidationSupport;
+
+  @BeforeEach
+  void setUp() {
+    fhirContext = FhirContext.forR4();
+    validationSupport = new CustomUnknownCodeSystemWarningValidationSupport(fhirContext);
+  }
+
+  @Test
+  void testConstructorSetsFhirContext() {
+    assertThat(validationSupport.getFhirContext(), is(notNullValue()));
+    assertThat(validationSupport.getFhirContext(), is(fhirContext));
+  }
+
+  @Test
+  void testGetNameReturnsExpectedValue() {
+    String name = validationSupport.getName();
+    assertThat(name, containsString("Unknown Code System Warning Validation Support"));
+  }
+
+
+  @Test
+  void testIsValueSetSupportedAlwaysReturnsTrue() {
+    boolean result =
+        validationSupport.isValueSetSupported(
+            validationSupportContext, "http://example.com/ValueSet/test");
+    assertThat(result, is(true));
+  }
+
+  @Test
+  void testIsValueSetSupportedReturnsTrueForNullUrl() {
+    boolean result = validationSupport.isValueSetSupported(validationSupportContext, null);
+    assertThat(result, is(true));
+  }
+
+  @Test
+  void testIsCodeSystemSupportedReturnsFalseWhenSeverityIsError() {
+    // Default severity is ERROR, so allowNonExistentCodeSystems returns false early
+    // No mocks needed - the method returns false without checking code system
+    boolean result =
+        validationSupport.isCodeSystemSupported(
+            validationSupportContext, "http://example.com/CodeSystem/test");
+
+    assertThat(result, is(false));
+  }
+
+  @Test
+  void testIsCodeSystemSupportedReturnsTrueWhenSeverityIsWarning() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(null);
+
+    boolean result =
+        validationSupport.isCodeSystemSupported(
+            validationSupportContext, "http://example.com/CodeSystem/test");
+
+    assertThat(result, is(true));
+  }
+
+  @Test
+  void testIsCodeSystemSupportedReturnsFalseWhenCodeSystemExists() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(new CodeSystem());
+
+    boolean result =
+        validationSupport.isCodeSystemSupported(
+            validationSupportContext, "http://example.com/CodeSystem/test");
+
+    assertThat(result, is(false));
+  }
+
+  @Test
+  void testIsCodeSystemSupportedReturnsFalseForNullCodeSystem() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+
+    boolean result = validationSupport.isCodeSystemSupported(validationSupportContext, null);
+
+    assertThat(result, is(false));
+  }
+
+  @Test
+  void testLookupCodeReturnsNullWhenSeverityIsError() {
+    // Default severity is ERROR, so canValidateCodeSystem returns false early
+    // No mocks needed - the method returns null without checking code system
+    LookupCodeRequest request = new LookupCodeRequest("http://example.com/CodeSystem/test", "code");
+    LookupCodeResult result = validationSupport.lookupCode(validationSupportContext, request);
+
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  void testLookupCodeReturnsFoundWhenSeverityIsWarning() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(null);
+
+    LookupCodeRequest request = new LookupCodeRequest("http://example.com/CodeSystem/test", "code");
+    LookupCodeResult result = validationSupport.lookupCode(validationSupportContext, request);
+
+    assertThat(result, is(notNullValue()));
+    assertThat(result.isFound(), is(true));
+  }
+
+  @Test
+  void testLookupCodeReturnsFoundWhenSeverityIsInformation() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.INFORMATION);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(null);
+
+    LookupCodeRequest request = new LookupCodeRequest("http://example.com/CodeSystem/test", "code");
+    LookupCodeResult result = validationSupport.lookupCode(validationSupportContext, request);
+
+    assertThat(result, is(notNullValue()));
+    assertThat(result.isFound(), is(true));
+  }
+
+  @Test
+  void testLookupCodeReturnsNullWhenCodeSystemExists() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(new CodeSystem());
+
+    LookupCodeRequest request = new LookupCodeRequest("http://example.com/CodeSystem/test", "code");
+    LookupCodeResult result = validationSupport.lookupCode(validationSupportContext, request);
+
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  void testValidateCodeReturnsNullWhenSeverityIsError() {
+    // Default severity is ERROR, so canValidateCodeSystem returns false early
+    // No mocks needed - the method returns null without checking code system
+    CodeValidationResult result =
+        validationSupport.validateCode(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://example.com/CodeSystem/test",
+            "code",
+            "display",
+            "http://example.com/ValueSet/test");
+
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  void testValidateCodeReturnsWarningWhenSeverityIsWarning() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(null);
+
+    CodeValidationResult result =
+        validationSupport.validateCode(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://example.com/CodeSystem/test",
+            "testCode",
+            "display",
+            "http://example.com/ValueSet/test");
+
+    assertThat(result, is(notNullValue()));
+    assertThat(result.getSeverity(), is(IssueSeverity.WARNING));
+    assertThat(result.getMessage(), containsString("CodeSystem is unknown"));
+    assertThat(result.getMessage(), containsString("http://example.com/CodeSystem/test"));
+    assertThat(result.getMessage(), containsString("testCode"));
+    assertThat(result.getIssues(), is(notNullValue()));
+    assertThat(result.getIssues().size(), is(1));
+  }
+
+  @Test
+  void testValidateCodeReturnsInformationWithNullSeverityAndMessage() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.INFORMATION);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(null);
+
+    CodeValidationResult result =
+        validationSupport.validateCode(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://example.com/CodeSystem/test",
+            "testCode",
+            "display",
+            "http://example.com/ValueSet/test");
+
+    assertThat(result, is(notNullValue()));
+    assertThat(result.getSeverity(), is(nullValue()));
+    assertThat(result.getMessage(), is(nullValue()));
+    assertThat(result.getCode(), is("testCode"));
+  }
+
+  @Test
+  void testValidateCodeReturnsNullWhenCodeSystemExists() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(new CodeSystem());
+
+    CodeValidationResult result =
+        validationSupport.validateCode(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://example.com/CodeSystem/test",
+            "code",
+            "display",
+            "http://example.com/ValueSet/test");
+
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  void testValidateCodeReturnsNullForNullCodeSystem() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+
+    CodeValidationResult result =
+        validationSupport.validateCode(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            null,
+            "code",
+            "display",
+            "http://example.com/ValueSet/test");
+
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  void testValidateCodeInValueSetReturnsNullWhenSeverityIsError() {
+    // Default severity is ERROR, so canValidateCodeSystem returns false early
+    // No mocks needed - the method returns null without checking code system
+    ValueSet valueSet = new ValueSet();
+    CodeValidationResult result =
+        validationSupport.validateCodeInValueSet(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://example.com/CodeSystem/test",
+            "code",
+            "display",
+            valueSet);
+
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  void testValidateCodeInValueSetReturnsInformationWhenSeverityIsWarning() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(null);
+
+    ValueSet valueSet = new ValueSet();
+    CodeValidationResult result =
+        validationSupport.validateCodeInValueSet(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://example.com/CodeSystem/test",
+            "testCode",
+            "display",
+            valueSet);
+
+    assertThat(result, is(notNullValue()));
+    assertThat(result.getSeverity(), is(IssueSeverity.INFORMATION));
+    assertThat(result.getCode(), is("testCode"));
+    assertThat(result.getMessage(), containsString("was not checked"));
+    assertThat(result.getMessage(), containsString("CodeSystem is not available"));
+  }
+
+  @Test
+  void testValidateCodeInValueSetReturnsNullWhenCodeSystemExists() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(new CodeSystem());
+
+    ValueSet valueSet = new ValueSet();
+    CodeValidationResult result =
+        validationSupport.validateCodeInValueSet(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://example.com/CodeSystem/test",
+            "code",
+            "display",
+            valueSet);
+
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  void testValidateCodeInValueSetReturnsNullForNullCodeSystem() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+
+    ValueSet valueSet = new ValueSet();
+    CodeValidationResult result =
+        validationSupport.validateCodeInValueSet(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            null,
+            "code",
+            "display",
+            valueSet);
+
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  void testSetNonExistentCodeSystemSeverityToWarning() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(null);
+
+    CodeValidationResult result =
+        validationSupport.validateCode(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://example.com/CodeSystem/test",
+            "code",
+            "display",
+            null);
+
+    assertThat(result, is(notNullValue()));
+    assertThat(result.getSeverity(), is(IssueSeverity.WARNING));
+  }
+
+  @Test
+  void testSetNonExistentCodeSystemSeverityThrowsOnNull() {
+    assertThrows(
+        NullPointerException.class, () -> validationSupport.setNonExistentCodeSystemSeverity(null));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testSetAllowNonExistentCodeSystemTrueSetsSeverityToWarning() {
+    validationSupport.setAllowNonExistentCodeSystem(true);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem(anyString())).thenReturn(null);
+
+    CodeValidationResult result =
+        validationSupport.validateCode(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://example.com/CodeSystem/test",
+            "code",
+            "display",
+            null);
+
+    assertThat(result, is(notNullValue()));
+    assertThat(result.getSeverity(), is(IssueSeverity.WARNING));
+  }
+
+  @Test
+  void testSetAllowNonExistentCodeSystemFalseSetsSeverityToError() {
+    // First set to WARNING
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    // Then set to not allow (ERROR)
+    validationSupport.setAllowNonExistentCodeSystem(false);
+    // ERROR severity means canValidateCodeSystem returns false early
+    // No mocks needed - the method returns null without checking code system
+
+    CodeValidationResult result =
+        validationSupport.validateCode(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://example.com/CodeSystem/test",
+            "code",
+            "display",
+            null);
+
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  void testValidationFlowWithWarningForUnknownCodeSystem() {
+    validationSupport.setNonExistentCodeSystemSeverity(IssueSeverity.WARNING);
+    when(validationSupportContext.getRootValidationSupport()).thenReturn(rootValidationSupport);
+    when(rootValidationSupport.fetchCodeSystem("http://unknown.system")).thenReturn(null);
+    when(rootValidationSupport.fetchCodeSystem("http://known.system")).thenReturn(new CodeSystem());
+
+    // Unknown code system should return warning
+    CodeValidationResult unknownResult =
+        validationSupport.validateCode(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://unknown.system",
+            "code",
+            "display",
+            null);
+    assertThat(unknownResult, is(notNullValue()));
+    assertThat(unknownResult.getSeverity(), is(IssueSeverity.WARNING));
+
+    // Known code system should return null (let other validators handle it)
+    CodeValidationResult knownResult =
+        validationSupport.validateCode(
+            validationSupportContext,
+            new ConceptValidationOptions(),
+            "http://known.system",
+            "code",
+            "display",
+            null);
+    assertThat(knownResult, is(nullValue()));
+  }
+}


### PR DESCRIPTION
MAT-9536 maintaining a copy of hapi-fhir UnknownCodeSystemWarningValidationSupport because-
- it is deprecated it in hapi-fhir v8.6.1 AND
- it is recommended to use ValidationMessageUnknownCodeSystemPostProcessingInterceptor interceptor however this is server interceptor and we are not using hapi-fhir server. we are using hapi validators in standalone mode using FhirInstanceValidator. Therefore this does not work for us.

## MADiE FHIR SERVICE

Jira Ticket: [MAT-9536](https://jira.cms.gov/browse/MAT-9536)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
