### PR TITLE
MAT-9577: Remove Resources with Invalid References from Test Case Bundles

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/dto/ExecutionBundleDTO.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/dto/ExecutionBundleDTO.java
@@ -1,0 +1,15 @@
+package gov.cms.madie.madiefhirservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class ExecutionBundleDTO {
+  private String bundle;
+  private String testCaseId;
+}

--- a/src/main/java/gov/cms/madie/madiefhirservice/dto/TestCaseExecutionBundlesDTO.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/dto/TestCaseExecutionBundlesDTO.java
@@ -1,15 +1,18 @@
 package gov.cms.madie.madiefhirservice.dto;
 
+import gov.cms.madie.models.measure.TestCase;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder(toBuilder = true)
-public class ExecutionBundleDTO {
-  private String bundle;
-  private String testCaseId;
+public class TestCaseExecutionBundlesDTO {
+  private List<TestCase> testCases;
+  private List<String> modifiedTestCaseIds;
 }

--- a/src/main/java/gov/cms/madie/madiefhirservice/exceptions/BundleOperationException.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/exceptions/BundleOperationException.java
@@ -1,5 +1,9 @@
 package gov.cms.madie.madiefhirservice.exceptions;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
 public class BundleOperationException extends RuntimeException {
   private static final String MESSAGE =
       "An error occurred while bundling %s with ID %s. "

--- a/src/main/java/gov/cms/madie/madiefhirservice/factories/ModelAwareFhirFactory.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/factories/ModelAwareFhirFactory.java
@@ -62,7 +62,7 @@ public class ModelAwareFhirFactory {
    * @param bundleString
    * @return
    * @throws DataFormatException
-   * @throws ClassCastException
+   * @throws UnsupportedTypeException
    */
   public IBaseBundle parseForModel(ModelType modelType, String bundleString) {
     IParser parser = this.getJsonParserForModel(modelType);

--- a/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.parser.IParser;
 import gov.cms.madie.madiefhirservice.dto.TestCaseExecutionBundlesDTO;
 import gov.cms.madie.madiefhirservice.exceptions.BundleOperationException;
 import gov.cms.madie.madiefhirservice.exceptions.ResourceNotFoundException;
+import gov.cms.madie.madiefhirservice.exceptions.UnsupportedTypeException;
 import gov.cms.madie.madiefhirservice.factories.ModelAwareFhirFactory;
 import gov.cms.madie.madiefhirservice.services.ResourceValidationService;
 import gov.cms.madie.madiefhirservice.services.TestCaseBundleService;
@@ -173,16 +174,8 @@ public class TestCaseBundleController {
     IBaseBundle bundle;
     try {
       bundle = fhirModelFactory.parseForModel(modelType, testCase.getJson());
-    } catch (DataFormatException | ClassCastException ex) {
+    } catch (DataFormatException | UnsupportedTypeException ex) {
       throw new BundleOperationException("Test Case", testCase.getId(), ex);
-    }
-
-    // only operate on bundles
-    if (!"BUNDLE".equalsIgnoreCase(bundle.fhirType())) {
-      throw new BundleOperationException(
-          "Test Case",
-          testCase.getId(),
-          new IllegalArgumentException("Resource must have resourceType of 'Bundle'"));
     }
     return bundle;
   }

--- a/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
@@ -1,41 +1,49 @@
 package gov.cms.madie.madiefhirservice.resources;
 
-import java.security.Principal;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.hl7.fhir.r4.model.Bundle;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.DataFormatException;
+import ca.uhn.fhir.parser.IParser;
+import gov.cms.madie.madiefhirservice.dto.ExecutionBundleDTO;
+import gov.cms.madie.madiefhirservice.exceptions.BundleOperationException;
 import gov.cms.madie.madiefhirservice.exceptions.ResourceNotFoundException;
+import gov.cms.madie.madiefhirservice.factories.ModelAwareFhirFactory;
+import gov.cms.madie.madiefhirservice.services.ResourceValidationService;
 import gov.cms.madie.madiefhirservice.services.TestCaseBundleService;
 import gov.cms.madie.madiefhirservice.utils.ExportFileNamesUtil;
+import gov.cms.madie.models.common.ModelType;
 import gov.cms.madie.models.dto.ExportDTO;
 import gov.cms.madie.models.measure.Measure;
 import gov.cms.madie.models.measure.TestCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static gov.cms.madie.madiefhirservice.utils.ModelEndpointMap.QICORE_VERSION_MODELTYPE_MAP;
 
 @Slf4j
 @RestController
 @RequestMapping(path = "/fhir/test-cases")
 @Tag(
     name = "TestCase-Bundle-Controller",
-    description = "API for generating test case bundle for export")
-@RequiredArgsConstructor
+    description = "API for generating test case bundle for export and execution")
+@AllArgsConstructor
 public class TestCaseBundleController {
 
   private final TestCaseBundleService testCaseBundleService;
+  private final ModelAwareFhirFactory fhirModelFactory;
+  private final ResourceValidationService validationService;
 
   @PutMapping("/export-all")
   public ResponseEntity<byte[]> getTestCaseExportBundle(
@@ -109,5 +117,59 @@ public class TestCaseBundleController {
             .filter(testCase -> !exportablePatientIds.contains(testCase.getPatientId().toString()))
             .collect(Collectors.toList());
     return missingTestCases;
+  }
+
+  @PostMapping(
+      path = "/qicore/{model}/execution-bundles",
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<List<ExecutionBundleDTO>> getTestCaseExecutionBundle(
+      @PathVariable("model") String modelVersion,
+      @RequestBody List<TestCase> testCases,
+      HttpEntity<String> request) {
+    final ModelType modelType = QICORE_VERSION_MODELTYPE_MAP.get(modelVersion);
+    IParser parser = fhirModelFactory.getJsonParserForModel(modelType);
+    FhirContext fhirContext = fhirModelFactory.getContextForModel(modelType);
+
+    List<ExecutionBundleDTO> executionBundles = new ArrayList<>();
+    for (TestCase testCase : testCases) {
+      IBaseBundle bundle;
+      try {
+        bundle = fhirModelFactory.parseForModel(modelType, testCase.getJson());
+      } catch (DataFormatException | ClassCastException ex) {
+        throw new BundleOperationException("Test Case", testCase.getId(), ex);
+      }
+
+      // only operate on bundles
+      if (!"BUNDLE".equalsIgnoreCase(bundle.fhirType())) {
+        throw new BundleOperationException(
+            "Test Case",
+            testCase.getId(),
+            new IllegalArgumentException("Resource must have resourceType of 'Bundle'"));
+      }
+
+      // find any resources with invalid references.
+      Set<IBaseResource> resourcesWithInvalidReferences =
+          validationService.findResourcesWithInvalidReferences(fhirContext, bundle);
+      List<Bundle.BundleEntryComponent> validResources =
+          ((Bundle) bundle)
+              .getEntry().stream()
+                  .filter(entry -> !resourcesWithInvalidReferences.contains(entry.getResource()))
+                  .toList();
+
+      // if there are invalid references, create a new bundle with only the valid resources.
+      if (validResources.size() != ((Bundle) bundle).getEntry().size()) {
+        ExecutionBundleDTO executionBundleDTO =
+            ExecutionBundleDTO.builder()
+                .bundle(
+                    parser.encodeResourceToString(
+                        ((Bundle) bundle).copy().setEntry(validResources)))
+                .testCaseId(testCase.getId())
+                .build();
+        executionBundles.add(executionBundleDTO);
+      }
+    }
+    // return modified bundles with their test case IDs.
+    return ResponseEntity.ok(executionBundles);
   }
 }

--- a/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
@@ -3,7 +3,7 @@ package gov.cms.madie.madiefhirservice.resources;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.parser.IParser;
-import gov.cms.madie.madiefhirservice.dto.ExecutionBundleDTO;
+import gov.cms.madie.madiefhirservice.dto.TestCaseExecutionBundlesDTO;
 import gov.cms.madie.madiefhirservice.exceptions.BundleOperationException;
 import gov.cms.madie.madiefhirservice.exceptions.ResourceNotFoundException;
 import gov.cms.madie.madiefhirservice.factories.ModelAwareFhirFactory;
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
+import org.jspecify.annotations.NonNull;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -123,7 +124,7 @@ public class TestCaseBundleController {
       path = "/qicore/{model}/execution-bundles",
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<List<ExecutionBundleDTO>> getTestCaseExecutionBundle(
+  public ResponseEntity<TestCaseExecutionBundlesDTO> getTestCaseExecutionBundle(
       @PathVariable("model") String modelVersion,
       @RequestBody List<TestCase> testCases,
       HttpEntity<String> request) {
@@ -131,45 +132,52 @@ public class TestCaseBundleController {
     IParser parser = fhirModelFactory.getJsonParserForModel(modelType);
     FhirContext fhirContext = fhirModelFactory.getContextForModel(modelType);
 
-    List<ExecutionBundleDTO> executionBundles = new ArrayList<>();
+    List<String> modifiedTestCaseIds = new ArrayList<>();
     for (TestCase testCase : testCases) {
-      IBaseBundle bundle;
-      try {
-        bundle = fhirModelFactory.parseForModel(modelType, testCase.getJson());
-      } catch (DataFormatException | ClassCastException ex) {
-        throw new BundleOperationException("Test Case", testCase.getId(), ex);
-      }
-
-      // only operate on bundles
-      if (!"BUNDLE".equalsIgnoreCase(bundle.fhirType())) {
-        throw new BundleOperationException(
-            "Test Case",
-            testCase.getId(),
-            new IllegalArgumentException("Resource must have resourceType of 'Bundle'"));
-      }
+      IBaseBundle bundle = parseBundleFromTestCase(testCase, modelType);
 
       // find any resources with invalid references.
       Set<IBaseResource> resourcesWithInvalidReferences =
           validationService.findResourcesWithInvalidReferences(fhirContext, bundle);
+      // create list of valid resources.
       List<Bundle.BundleEntryComponent> validResources =
           ((Bundle) bundle)
               .getEntry().stream()
                   .filter(entry -> !resourcesWithInvalidReferences.contains(entry.getResource()))
                   .toList();
 
-      // if there are invalid references, create a new bundle with only the valid resources.
       if (validResources.size() != ((Bundle) bundle).getEntry().size()) {
-        ExecutionBundleDTO executionBundleDTO =
-            ExecutionBundleDTO.builder()
-                .bundle(
-                    parser.encodeResourceToString(
-                        ((Bundle) bundle).copy().setEntry(validResources)))
-                .testCaseId(testCase.getId())
-                .build();
-        executionBundles.add(executionBundleDTO);
+        Bundle modifiedBundle = ((Bundle) bundle).copy().setEntry(validResources);
+        try {
+          testCase.setJson(parser.encodeResourceToString(modifiedBundle));
+          modifiedTestCaseIds.add(testCase.getId());
+        } catch (DataFormatException ex) {
+          testCase.setJson(testCase.getJson());
+        }
       }
     }
-    // return modified bundles with their test case IDs.
-    return ResponseEntity.ok(executionBundles);
+    return ResponseEntity.ok(
+        TestCaseExecutionBundlesDTO.builder()
+            .testCases(testCases)
+            .modifiedTestCaseIds(modifiedTestCaseIds)
+            .build());
+  }
+
+  private @NonNull IBaseBundle parseBundleFromTestCase(TestCase testCase, ModelType modelType) {
+    IBaseBundle bundle;
+    try {
+      bundle = fhirModelFactory.parseForModel(modelType, testCase.getJson());
+    } catch (DataFormatException | ClassCastException ex) {
+      throw new BundleOperationException("Test Case", testCase.getId(), ex);
+    }
+
+    // only operate on bundles
+    if (!"BUNDLE".equalsIgnoreCase(bundle.fhirType())) {
+      throw new BundleOperationException(
+          "Test Case",
+          testCase.getId(),
+          new IllegalArgumentException("Resource must have resourceType of 'Bundle'"));
+    }
+    return bundle;
   }
 }

--- a/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
@@ -133,6 +133,7 @@ public class TestCaseBundleController {
     FhirContext fhirContext = fhirModelFactory.getContextForModel(modelType);
 
     List<String> modifiedTestCaseIds = new ArrayList<>();
+    List<TestCase> malformedTestCases = new ArrayList<>();
     for (TestCase testCase : testCases) {
       IBaseBundle bundle = parseBundleFromTestCase(testCase, modelType);
 
@@ -150,12 +151,17 @@ public class TestCaseBundleController {
         Bundle modifiedBundle = ((Bundle) bundle).copy().setEntry(validResources);
         try {
           testCase.setJson(parser.encodeResourceToString(modifiedBundle));
-          modifiedTestCaseIds.add(testCase.getId());
         } catch (DataFormatException ex) {
-          testCase.setJson(testCase.getJson());
+          log.error(
+              "Error re-encoding modified bundle for Test Case [{}]: {}",
+              testCase.getId(),
+              ex.getMessage());
+          malformedTestCases.add(testCase);
         }
+        modifiedTestCaseIds.add(testCase.getId());
       }
     }
+    testCases.removeAll(malformedTestCases);
     return ResponseEntity.ok(
         TestCaseExecutionBundlesDTO.builder()
             .testCases(testCases)

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/ResourceValidationService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/ResourceValidationService.java
@@ -138,15 +138,13 @@ public class ResourceValidationService {
             .getValues(resource)
             .forEach(
                 iBase -> {
-                  if (iBase instanceof IBaseReference baseReference) {
-                    if (isInvalidReferenceToBundleEntry(baseReference, existingIds)) {
-                      resourcesWithInvalidReferences.add(resource);
-                    }
-                  } else if (iBase instanceof IBaseBackboneElement backboneElement) {
-                    if (hasInvalidReferencesInBackboneToBundleEntries(
-                        fhirContext, backboneElement, existingIds)) {
-                      resourcesWithInvalidReferences.add(resource);
-                    }
+                  if (iBase instanceof IBaseReference baseReference
+                      && isInvalidReferenceToBundleEntry(baseReference, existingIds)) {
+                    resourcesWithInvalidReferences.add(resource);
+                  } else if (iBase instanceof IBaseBackboneElement backboneElement
+                      && hasInvalidReferencesInBackboneToBundleEntries(
+                          fhirContext, backboneElement, existingIds)) {
+                    resourcesWithInvalidReferences.add(resource);
                   }
                 });
       }
@@ -195,18 +193,14 @@ public class ResourceValidationService {
 
       for (IBase value : values) {
         // Check if this is a Reference
-        if (value instanceof IBaseReference baseReference) {
-          if (isInvalidReferenceToBundleEntry(baseReference, existingIds)) {
-            return true;
-          }
-        }
-
-        // Check if this is a nested Backbone Element (recursion)
-        else if (value instanceof IBaseBackboneElement nestedBackbone) {
-          if (hasInvalidReferencesInBackboneToBundleEntries(
-              fhirContext, nestedBackbone, existingIds)) {
-            return true;
-          }
+        if (value instanceof IBaseReference baseReference
+            && isInvalidReferenceToBundleEntry(baseReference, existingIds)) {
+          return true;
+          // Check if this is a nested Backbone Element (recursion)
+        } else if (value instanceof IBaseBackboneElement nestedBackbone
+            && hasInvalidReferencesInBackboneToBundleEntries(
+                fhirContext, nestedBackbone, existingIds)) {
+          return true;
         }
       }
     }

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/ResourceValidationService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/ResourceValidationService.java
@@ -1,6 +1,7 @@
 package gov.cms.madie.madiefhirservice.services;
 
 import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
+import ca.uhn.fhir.context.BaseRuntimeElementCompositeDefinition;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.parser.IParser;
@@ -13,20 +14,14 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.instance.model.api.IBaseBundle;
-import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
-import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -101,6 +96,121 @@ public class ResourceValidationService {
       }
     }
     return operationOutcome;
+  }
+
+  /**
+   * Finds resources within the given Bundle that contain invalid references. A Reference is
+   * considered invalid if it does not resolve to any other Resource within the same Bundle.
+   *
+   * @param fhirContext The FHIR context, specifies the FHIR version.
+   * @param bundleResource The Bundle to validate.
+   * @return Set of Resources with invalid references.
+   */
+  public Set<IBaseResource> findResourcesWithInvalidReferences(
+      FhirContext fhirContext, IBaseBundle bundleResource) {
+    List<IBaseResource> resources = BundleUtil.toListOfResources(fhirContext, bundleResource);
+    return findResourcesWithInvalidReferences(fhirContext, resources);
+  }
+
+  private Set<IBaseResource> findResourcesWithInvalidReferences(
+      FhirContext fhirContext, List<IBaseResource> resources) {
+    Set<IBaseResource> resourcesWithInvalidReferences = new HashSet<>();
+
+    // List of existing Ids in Bundle in the format "ResourceType/ID"
+    List<String> existingIds =
+        resources.stream()
+            .map(
+                resource ->
+                    resource.getIdElement().getResourceType()
+                        + "/"
+                        + resource.getIdElement().getIdPart())
+            .toList();
+
+    for (IBaseResource resource : resources) {
+
+      // HAPI's Runtime access to Resources
+      RuntimeResourceDefinition resourceDefinition = fhirContext.getResourceDefinition(resource);
+
+      // Loop over the children of the Resource to find Reference fields
+      for (BaseRuntimeChildDefinition child : resourceDefinition.getChildren()) {
+        child
+            .getAccessor()
+            .getValues(resource)
+            .forEach(
+                iBase -> {
+                  if (iBase instanceof IBaseReference baseReference) {
+                    if (isInvalidReferenceToBundleEntry(baseReference, existingIds)) {
+                      resourcesWithInvalidReferences.add(resource);
+                    }
+                  } else if (iBase instanceof IBaseBackboneElement backboneElement) {
+                    if (hasInvalidReferencesInBackboneToBundleEntries(
+                        fhirContext, backboneElement, existingIds)) {
+                      resourcesWithInvalidReferences.add(resource);
+                    }
+                  }
+                });
+      }
+    }
+    return resourcesWithInvalidReferences;
+  }
+
+  private boolean isInvalidReferenceToBundleEntry(
+      IBaseReference reference, List<String> existingIds) {
+    IIdType refElement = reference.getReferenceElement();
+
+    if (refElement == null || refElement.getResourceType() == null) {
+      return true; // Invalid reference
+    }
+
+    String refValue = refElement.getResourceType() + "/" + refElement.getIdPart();
+
+    if (!existingIds.contains(refValue)) {
+      log.debug("Found invalid reference to {} in Reference element", refValue);
+      return true;
+    }
+    return false; // Reference is valid
+  }
+
+  /**
+   * Recursively checks for invalid references within a backbone element and its nested backbone
+   * elements.
+   *
+   * @param fhirContext The FHIR context
+   * @param backbone The backbone element to check
+   * @param existingIds List of valid resource identifiers in format "ResourceType/Id"
+   * @return true if any invalid reference is found
+   */
+  private boolean hasInvalidReferencesInBackboneToBundleEntries(
+      FhirContext fhirContext, IBaseBackboneElement backbone, List<String> existingIds) {
+
+    // Get the definition for this backbone element
+    // Use getElementDefinition instead of getResourceDefinition
+    BaseRuntimeElementCompositeDefinition<?> backboneDef =
+        (BaseRuntimeElementCompositeDefinition<?>)
+            fhirContext.getElementDefinition(backbone.getClass());
+
+    // Iterate through all children of the backbone element
+    for (BaseRuntimeChildDefinition child : backboneDef.getChildren()) {
+      List<IBase> values = child.getAccessor().getValues(backbone);
+
+      for (IBase value : values) {
+        // Check if this is a Reference
+        if (value instanceof IBaseReference baseReference) {
+          if (isInvalidReferenceToBundleEntry(baseReference, existingIds)) {
+            return true;
+          }
+        }
+
+        // Check if this is a nested Backbone Element (recursion)
+        else if (value instanceof IBaseBackboneElement nestedBackbone) {
+          if (hasInvalidReferencesInBackboneToBundleEntries(
+              fhirContext, nestedBackbone, existingIds)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false; // No invalid references found
   }
 
   public boolean isSuccessful(FhirContext fhirContext, IBaseOperationOutcome outcome) {

--- a/src/test/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleControllerMvcTest.java
@@ -1,8 +1,12 @@
 package gov.cms.madie.madiefhirservice.resources;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.DataFormatException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cms.madie.madiefhirservice.dto.ExecutionBundleDTO;
+import gov.cms.madie.madiefhirservice.factories.ModelAwareFhirFactory;
+import gov.cms.madie.madiefhirservice.services.ResourceValidationService;
 import gov.cms.madie.madiefhirservice.services.TestCaseBundleService;
 import gov.cms.madie.madiefhirservice.utils.ResourceFileUtil;
 import gov.cms.madie.models.common.BundleType;
@@ -16,17 +20,23 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
 import java.security.Principal;
 import java.util.*;
 
 import static java.util.Arrays.asList;
-import static org.mockito.ArgumentMatchers.any;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -39,23 +49,23 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
   private static final String TEST_CASE_ID = "62fe4466848fd80e1dd3edd0";
   private static final String TEST_CASE_ID_2 = "62fe4466848fd80e1dd3edd1";
 
-  @MockBean private TestCaseBundleService testCaseBundleService;
+  @MockitoBean private ModelAwareFhirFactory fhirModelFactory;
+  @MockitoBean private TestCaseBundleService testCaseBundleService;
+  @MockitoBean private ResourceValidationService validationService;
 
   @Autowired private MockMvc mockMvc;
 
   @Autowired private ObjectMapper mapper;
 
-  @Captor private ArgumentCaptor<List> testCaseListCaptor;
+  @Captor private ArgumentCaptor<List<TestCase>> testCaseListCaptor;
 
   private Bundle testCaseBundle;
-
-  private String madieMeasureJson;
 
   private ExportDTO dto;
 
   @BeforeEach
   public void setUp() throws JsonProcessingException {
-    madieMeasureJson = getStringFromTestResource("/measures/madie_measure.json");
+    String madieMeasureJson = getStringFromTestResource("/measures/madie_measure.json");
     String testCaseJson = getStringFromTestResource("/testCaseBundles/validTestCase.json");
     testCaseBundle = FhirContext.forR4().newJsonParser().parseResource(Bundle.class, testCaseJson);
     dto =
@@ -77,7 +87,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     testCaseBundleMap.put(
         dto.getMeasure().getTestCases().get(1).getPatientId().toString(), testCaseBundle);
     when(testCaseBundleService.getTestCaseExportBundle(
-            any(Measure.class), any(List.class), any(ExportDTO.class)))
+            any(Measure.class), anyList(), any(ExportDTO.class)))
         .thenReturn(testCaseBundleMap);
     mockMvc
         .perform(
@@ -89,7 +99,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk());
     verify(testCaseBundleService, times(1))
-        .getTestCaseExportBundle(any(Measure.class), any(List.class), any(ExportDTO.class));
+        .getTestCaseExportBundle(any(Measure.class), anyList(), any(ExportDTO.class));
   }
 
   @Test
@@ -104,7 +114,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     testCaseBundleMap.put(
         dto.getMeasure().getTestCases().get(1).getPatientId().toString(), testCaseBundle);
     when(testCaseBundleService.getTestCaseExportBundle(
-            any(Measure.class), any(List.class), any(ExportDTO.class)))
+            any(Measure.class), anyList(), any(ExportDTO.class)))
         .thenReturn(testCaseBundleMap);
     mockMvc
         .perform(
@@ -116,7 +126,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk());
     verify(testCaseBundleService, times(1))
-        .getTestCaseExportBundle(any(Measure.class), any(List.class), any(ExportDTO.class));
+        .getTestCaseExportBundle(any(Measure.class), anyList(), any(ExportDTO.class));
   }
 
   @Test
@@ -143,7 +153,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     testCaseBundleMap.put(
         dto.getMeasure().getTestCases().get(1).getPatientId().toString(), testCaseBundle);
     when(testCaseBundleService.getTestCaseExportBundle(
-            any(Measure.class), any(List.class), any(ExportDTO.class)))
+            any(Measure.class), anyList(), any(ExportDTO.class)))
         .thenReturn(testCaseBundleMap);
     mockMvc
         .perform(
@@ -161,10 +171,9 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isPartialContent());
     verify(testCaseBundleService, times(1))
-        .getTestCaseExportBundle(any(Measure.class), any(List.class), any(ExportDTO.class));
+        .getTestCaseExportBundle(any(Measure.class), anyList(), any(ExportDTO.class));
     verify(testCaseBundleService, times(1))
-        .zipTestCaseContents(
-            any(Measure.class), any(Map.class), any(List.class), testCaseListCaptor.capture());
+        .zipTestCaseContents(any(Measure.class), anyMap(), anyList(), testCaseListCaptor.capture());
   }
 
   @Test
@@ -180,7 +189,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     testCaseBundleMap.put(
         dto.getMeasure().getTestCases().get(1).getPatientId().toString(), testCaseBundle);
     when(testCaseBundleService.getTestCaseExportBundle(
-            any(Measure.class), any(List.class), any(ExportDTO.class)))
+            any(Measure.class), anyList(), any(ExportDTO.class)))
         .thenReturn(testCaseBundleMap);
     mockMvc
         .perform(
@@ -192,7 +201,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk());
     verify(testCaseBundleService, times(1))
-        .getTestCaseExportBundle(any(Measure.class), any(List.class), any(ExportDTO.class));
+        .getTestCaseExportBundle(any(Measure.class), anyList(), any(ExportDTO.class));
   }
 
   @Test
@@ -238,7 +247,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     testCaseBundleMap.put(
         dto.getMeasure().getTestCases().get(0).getPatientId().toString(), testCaseBundle);
     when(testCaseBundleService.getTestCaseExportBundle(
-            any(Measure.class), any(List.class), any(ExportDTO.class)))
+            any(Measure.class), anyList(), any(ExportDTO.class)))
         .thenReturn(testCaseBundleMap);
     mockMvc
         .perform(
@@ -250,6 +259,164 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().is(206));
     verify(testCaseBundleService, times(1))
-        .getTestCaseExportBundle(any(Measure.class), any(List.class), any(ExportDTO.class));
+        .getTestCaseExportBundle(any(Measure.class), anyList(), any(ExportDTO.class));
+  }
+
+  @Test
+  void testReferencesInBundleValidation() throws Exception {
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn(TEST_USER_ID);
+
+    // Arrange
+    String testCaseJson = getStringFromTestResource("/testCaseBundles/validTestCase.json");
+    List<TestCase> testCases =
+        List.of(
+            TestCase.builder()
+                .id("test-case-valid-refs")
+                .patientId(UUID.randomUUID())
+                .title("Test Case with Valid References")
+                .series("HAPPY_PATH")
+                .json(testCaseJson)
+                .build());
+
+    // Mock the factory to return our test bundle
+    when(fhirModelFactory.parseForModel(any(), eq(testCaseJson))).thenReturn(new Bundle());
+    when(fhirModelFactory.getJsonParserForModel(any()))
+        .thenReturn(FhirContext.forR4().newJsonParser());
+    when(fhirModelFactory.getContextForModel(any())).thenReturn(FhirContext.forR4());
+
+    // Mock the validation service to indicate no invalid references
+    when(validationService.findResourcesWithInvalidReferences(
+            any(FhirContext.class), any(Bundle.class)))
+        .thenReturn(new HashSet<>()); // No invalid references
+
+    // Act
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/fhir/test-cases/qicore/4.1.1/execution-bundles")
+                .with(user(TEST_USER_ID))
+                .with(csrf())
+                .header(HttpHeaders.AUTHORIZATION, "test-okta")
+                .content(mapper.writeValueAsString(testCases))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andDo(
+            (result) -> assertThat(result.getResponse().getContentAsString(), is(notNullValue())))
+        .andExpect(status().isOk());
+
+    // Assert
+    verify(fhirModelFactory, times(1)).parseForModel(any(), anyString());
+    verify(validationService, times(1))
+        .findResourcesWithInvalidReferences(any(FhirContext.class), any(Bundle.class));
+  }
+
+  @Test
+  void testExecutionBundleReturnsModifiedBundles() throws Exception {
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn(TEST_USER_ID);
+
+    // Arrange
+    String testCaseJson =
+        getStringFromTestResource("/testCaseBundles/validTestCase.json")
+            .replace("Patient\\/1", "Patient\\/nope");
+    Bundle bundle = FhirContext.forR4().newJsonParser().parseResource(Bundle.class, testCaseJson);
+    List<TestCase> testCases =
+        List.of(
+            TestCase.builder()
+                .id("test-case-valid-refs")
+                .patientId(UUID.randomUUID())
+                .title("Test Case with Valid References")
+                .series("HAPPY_PATH")
+                .json(testCaseJson)
+                .build());
+
+    // Mock the factory to return our test bundle
+    when(fhirModelFactory.parseForModel(any(), anyString())).thenReturn(bundle);
+    when(fhirModelFactory.getJsonParserForModel(any()))
+        .thenReturn(FhirContext.forR4().newJsonParser());
+    when(fhirModelFactory.getContextForModel(any())).thenReturn(FhirContext.forR4());
+
+    // Mock the validation service to indicate no invalid references
+    when(validationService.findResourcesWithInvalidReferences(
+            any(FhirContext.class), any(Bundle.class)))
+        .thenReturn(
+            Set.of(bundle.getEntry().get(0).getResource())); // First entry has invalid reference
+
+    // Act
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/fhir/test-cases/qicore/4.1.1/execution-bundles")
+                .with(user(TEST_USER_ID))
+                .with(csrf())
+                .header(HttpHeaders.AUTHORIZATION, "test-okta")
+                .content(mapper.writeValueAsString(testCases))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andDo(
+            (result) -> {
+              String responseContent = result.getResponse().getContentAsString();
+              assertThat(responseContent, is(notNullValue()));
+              List<ExecutionBundleDTO> executionBundles =
+                  asList(mapper.readValue(responseContent, ExecutionBundleDTO[].class));
+              assertThat(executionBundles.size(), is(1));
+              ExecutionBundleDTO executionBundleDTO = executionBundles.get(0);
+              assertThat(executionBundleDTO.getTestCaseId(), is("test-case-valid-refs"));
+              Bundle returnedBundle =
+                  FhirContext.forR4()
+                      .newJsonParser()
+                      .parseResource(Bundle.class, executionBundleDTO.getBundle());
+              assertThat(
+                  returnedBundle.getEntry().size(), is(testCaseBundle.getEntry().size() - 1));
+            })
+        .andExpect(status().isOk());
+
+    // Assert
+    verify(fhirModelFactory, times(1)).parseForModel(any(), anyString());
+    verify(validationService, times(1))
+        .findResourcesWithInvalidReferences(any(FhirContext.class), any(Bundle.class));
+  }
+
+  @Test
+  void testExecutionBundleThrowsOnEmptyJson() throws Exception {
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn(TEST_USER_ID);
+
+    // Arrange
+    List<TestCase> testCases =
+        List.of(
+            TestCase.builder()
+                .id("test-case-valid-refs")
+                .patientId(UUID.randomUUID())
+                .title("Test Case with Valid References")
+                .series("ERROR_PATH")
+                .json("{}")
+                .build());
+
+    // Mock the factory to return our test bundle
+    when(fhirModelFactory.parseForModel(any(), anyString())).thenThrow(new DataFormatException());
+    when(fhirModelFactory.getJsonParserForModel(any()))
+        .thenReturn(FhirContext.forR4().newJsonParser());
+    when(fhirModelFactory.getContextForModel(any())).thenReturn(FhirContext.forR4());
+
+    // Mock the validation service to indicate no invalid references
+    when(validationService.findResourcesWithInvalidReferences(
+            any(FhirContext.class), any(Bundle.class)))
+        .thenReturn(new HashSet<>()); // No invalid references
+
+    // Act
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/fhir/test-cases/qicore/4.1.1/execution-bundles")
+                .with(user(TEST_USER_ID))
+                .with(csrf())
+                .header(HttpHeaders.AUTHORIZATION, "test-okta")
+                .content(mapper.writeValueAsString(testCases))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andDo(
+            (result) -> assertThat(result.getResponse().getContentAsString(), is(notNullValue())))
+        .andExpect(status().isBadRequest());
+
+    // Assert
+    verify(fhirModelFactory, times(1)).parseForModel(any(), anyString());
+    verify(validationService, times(0))
+        .findResourcesWithInvalidReferences(any(FhirContext.class), any(Bundle.class));
   }
 }

--- a/src/test/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleControllerMvcTest.java
@@ -4,7 +4,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.DataFormatException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.cms.madie.madiefhirservice.dto.ExecutionBundleDTO;
+import gov.cms.madie.madiefhirservice.dto.TestCaseExecutionBundlesDTO;
 import gov.cms.madie.madiefhirservice.factories.ModelAwareFhirFactory;
 import gov.cms.madie.madiefhirservice.services.ResourceValidationService;
 import gov.cms.madie.madiefhirservice.services.TestCaseBundleService;
@@ -33,6 +33,8 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.anyString;
@@ -239,7 +241,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
   }
 
   @Test
-  void getTestCaseExportAllReturnParialContent() throws Exception {
+  void getTestCaseExportAllReturnPartialContent() throws Exception {
     Principal principal = mock(Principal.class);
     when(principal.getName()).thenReturn(TEST_USER_ID);
 
@@ -300,7 +302,31 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
                 .content(mapper.writeValueAsString(testCases))
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
         .andDo(
-            (result) -> assertThat(result.getResponse().getContentAsString(), is(notNullValue())))
+            (result) -> {
+              String responseContent = result.getResponse().getContentAsString();
+              assertThat(responseContent, is(notNullValue()));
+              TestCaseExecutionBundlesDTO dto =
+                  mapper.readValue(responseContent, TestCaseExecutionBundlesDTO.class);
+              assertThat(dto.getTestCases().size(), is(testCases.size()));
+              assertThat(dto.getModifiedTestCaseIds().size(), is(0));
+              Bundle returnedBundle =
+                  FhirContext.forR4()
+                      .newJsonParser()
+                      .parseResource(Bundle.class, dto.getTestCases().get(0).getJson());
+              assertThat(returnedBundle.getEntry().size(), is(testCaseBundle.getEntry().size()));
+              assertTrue(
+                  returnedBundle
+                      .getEntry()
+                      .get(0)
+                      .getResource()
+                      .equalsDeep(testCaseBundle.getEntry().get(0).getResource()));
+              assertTrue(
+                  returnedBundle
+                      .getEntry()
+                      .get(1)
+                      .getResource()
+                      .equalsDeep(testCaseBundle.getEntry().get(1).getResource()));
+            })
         .andExpect(status().isOk());
 
     // Assert
@@ -315,12 +341,24 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     when(principal.getName()).thenReturn(TEST_USER_ID);
 
     // Arrange
-    String testCaseJson =
-        getStringFromTestResource("/testCaseBundles/validTestCase.json")
-            .replace("Patient\\/1", "Patient\\/nope");
+    String testCaseJson = getStringFromTestResource("/testCaseBundles/validTestCase.json");
+    String testCaseJsonWithInvalidReference = testCaseJson.replace("Patient\\/1", "Patient\\/nope");
+
+    Bundle bundleWithInvalidReference =
+        FhirContext.forR4()
+            .newJsonParser()
+            .parseResource(Bundle.class, testCaseJsonWithInvalidReference);
     Bundle bundle = FhirContext.forR4().newJsonParser().parseResource(Bundle.class, testCaseJson);
+
     List<TestCase> testCases =
         List.of(
+            TestCase.builder()
+                .id("test-case-invalid-refs")
+                .patientId(UUID.randomUUID())
+                .title("Test Case with Invalid References")
+                .series("HAPPY_PATH")
+                .json(testCaseJsonWithInvalidReference)
+                .build(),
             TestCase.builder()
                 .id("test-case-valid-refs")
                 .patientId(UUID.randomUUID())
@@ -330,16 +368,23 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
                 .build());
 
     // Mock the factory to return our test bundle
-    when(fhirModelFactory.parseForModel(any(), anyString())).thenReturn(bundle);
+    when(fhirModelFactory.parseForModel(any(), eq(testCaseJson))).thenReturn(bundle);
+    when(fhirModelFactory.parseForModel(any(), eq(testCaseJsonWithInvalidReference)))
+        .thenReturn(bundleWithInvalidReference);
     when(fhirModelFactory.getJsonParserForModel(any()))
         .thenReturn(FhirContext.forR4().newJsonParser());
     when(fhirModelFactory.getContextForModel(any())).thenReturn(FhirContext.forR4());
 
-    // Mock the validation service to indicate no invalid references
+    when(validationService.findResourcesWithInvalidReferences(any(FhirContext.class), eq(bundle)))
+        .thenReturn(new HashSet<>());
     when(validationService.findResourcesWithInvalidReferences(
-            any(FhirContext.class), any(Bundle.class)))
+            any(FhirContext.class), eq(bundleWithInvalidReference)))
         .thenReturn(
-            Set.of(bundle.getEntry().get(0).getResource())); // First entry has invalid reference
+            Set.of(
+                bundleWithInvalidReference
+                    .getEntry()
+                    .get(0)
+                    .getResource())); // First entry has invalid reference
 
     // Act
     mockMvc
@@ -354,23 +399,43 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
             (result) -> {
               String responseContent = result.getResponse().getContentAsString();
               assertThat(responseContent, is(notNullValue()));
-              List<ExecutionBundleDTO> executionBundles =
-                  asList(mapper.readValue(responseContent, ExecutionBundleDTO[].class));
-              assertThat(executionBundles.size(), is(1));
-              ExecutionBundleDTO executionBundleDTO = executionBundles.get(0);
-              assertThat(executionBundleDTO.getTestCaseId(), is("test-case-valid-refs"));
+              TestCaseExecutionBundlesDTO dto =
+                  mapper.readValue(responseContent, TestCaseExecutionBundlesDTO.class);
+              assertThat(dto.getTestCases().size(), is(testCases.size()));
+              assertThat(dto.getModifiedTestCaseIds().size(), is(1));
+              assertThat(dto.getModifiedTestCaseIds().get(0), is("test-case-invalid-refs"));
+              assertFalse(dto.getModifiedTestCaseIds().contains("test-case-valid-refs"));
+              Bundle returnedModifiedBundle =
+                  FhirContext.forR4()
+                      .newJsonParser()
+                      .parseResource(Bundle.class, dto.getTestCases().get(0).getJson());
+              assertThat(
+                  returnedModifiedBundle.getEntry().size(),
+                  is(bundleWithInvalidReference.getEntry().size() - 1));
+              assertTrue(
+                  returnedModifiedBundle
+                      .getEntry()
+                      .get(0)
+                      .getResource()
+                      .equalsDeep(bundleWithInvalidReference.getEntry().get(1).getResource()));
+
               Bundle returnedBundle =
                   FhirContext.forR4()
                       .newJsonParser()
-                      .parseResource(Bundle.class, executionBundleDTO.getBundle());
-              assertThat(
-                  returnedBundle.getEntry().size(), is(testCaseBundle.getEntry().size() - 1));
+                      .parseResource(Bundle.class, dto.getTestCases().get(1).getJson());
+              assertThat(returnedBundle.getEntry().size(), is(bundle.getEntry().size()));
+              assertTrue(
+                  returnedBundle
+                      .getEntry()
+                      .get(0)
+                      .getResource()
+                      .equalsDeep(bundle.getEntry().get(0).getResource()));
             })
         .andExpect(status().isOk());
 
     // Assert
-    verify(fhirModelFactory, times(1)).parseForModel(any(), anyString());
-    verify(validationService, times(1))
+    verify(fhirModelFactory, times(2)).parseForModel(any(), anyString());
+    verify(validationService, times(2))
         .findResourcesWithInvalidReferences(any(FhirContext.class), any(Bundle.class));
   }
 

--- a/src/test/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleControllerMvcTest.java
@@ -2,6 +2,7 @@ package gov.cms.madie.madiefhirservice.resources;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.DataFormatException;
+import ca.uhn.fhir.parser.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.madie.madiefhirservice.dto.TestCaseExecutionBundlesDTO;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
@@ -55,11 +57,15 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
   @MockitoBean private TestCaseBundleService testCaseBundleService;
   @MockitoBean private ResourceValidationService validationService;
 
+  @Mock JsonParser parser;
+
   @Autowired private MockMvc mockMvc;
 
   @Autowired private ObjectMapper mapper;
 
   @Captor private ArgumentCaptor<List<TestCase>> testCaseListCaptor;
+
+  private String testCaseJson;
 
   private Bundle testCaseBundle;
 
@@ -68,7 +74,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
   @BeforeEach
   public void setUp() throws JsonProcessingException {
     String madieMeasureJson = getStringFromTestResource("/measures/madie_measure.json");
-    String testCaseJson = getStringFromTestResource("/testCaseBundles/validTestCase.json");
+    testCaseJson = getStringFromTestResource("/testCaseBundles/validTestCase.json");
     testCaseBundle = FhirContext.forR4().newJsonParser().parseResource(Bundle.class, testCaseJson);
     dto =
         ExportDTO.builder()
@@ -265,12 +271,11 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
   }
 
   @Test
-  void testReferencesInBundleValidation() throws Exception {
+  void testValidReferencesInBundle() throws Exception {
     Principal principal = mock(Principal.class);
     when(principal.getName()).thenReturn(TEST_USER_ID);
 
     // Arrange
-    String testCaseJson = getStringFromTestResource("/testCaseBundles/validTestCase.json");
     List<TestCase> testCases =
         List.of(
             TestCase.builder()
@@ -282,7 +287,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
                 .build());
 
     // Mock the factory to return our test bundle
-    when(fhirModelFactory.parseForModel(any(), eq(testCaseJson))).thenReturn(new Bundle());
+    when(fhirModelFactory.parseForModel(any(), eq(testCaseJson))).thenReturn(testCaseBundle);
     when(fhirModelFactory.getJsonParserForModel(any()))
         .thenReturn(FhirContext.forR4().newJsonParser());
     when(fhirModelFactory.getContextForModel(any())).thenReturn(FhirContext.forR4());
@@ -295,7 +300,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     // Act
     mockMvc
         .perform(
-            MockMvcRequestBuilders.post("/fhir/test-cases/qicore/4.1.1/execution-bundles")
+            MockMvcRequestBuilders.post("/fhir/test-cases/qicore/4-1-1/execution-bundles")
                 .with(user(TEST_USER_ID))
                 .with(csrf())
                 .header(HttpHeaders.AUTHORIZATION, "test-okta")
@@ -341,14 +346,11 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     when(principal.getName()).thenReturn(TEST_USER_ID);
 
     // Arrange
-    String testCaseJson = getStringFromTestResource("/testCaseBundles/validTestCase.json");
     String testCaseJsonWithInvalidReference = testCaseJson.replace("Patient\\/1", "Patient\\/nope");
-
     Bundle bundleWithInvalidReference =
         FhirContext.forR4()
             .newJsonParser()
             .parseResource(Bundle.class, testCaseJsonWithInvalidReference);
-    Bundle bundle = FhirContext.forR4().newJsonParser().parseResource(Bundle.class, testCaseJson);
 
     List<TestCase> testCases =
         List.of(
@@ -368,14 +370,15 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
                 .build());
 
     // Mock the factory to return our test bundle
-    when(fhirModelFactory.parseForModel(any(), eq(testCaseJson))).thenReturn(bundle);
+    when(fhirModelFactory.parseForModel(any(), eq(testCaseJson))).thenReturn(testCaseBundle);
     when(fhirModelFactory.parseForModel(any(), eq(testCaseJsonWithInvalidReference)))
         .thenReturn(bundleWithInvalidReference);
     when(fhirModelFactory.getJsonParserForModel(any()))
         .thenReturn(FhirContext.forR4().newJsonParser());
     when(fhirModelFactory.getContextForModel(any())).thenReturn(FhirContext.forR4());
 
-    when(validationService.findResourcesWithInvalidReferences(any(FhirContext.class), eq(bundle)))
+    when(validationService.findResourcesWithInvalidReferences(
+            any(FhirContext.class), eq(testCaseBundle)))
         .thenReturn(new HashSet<>());
     when(validationService.findResourcesWithInvalidReferences(
             any(FhirContext.class), eq(bundleWithInvalidReference)))
@@ -389,7 +392,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     // Act
     mockMvc
         .perform(
-            MockMvcRequestBuilders.post("/fhir/test-cases/qicore/4.1.1/execution-bundles")
+            MockMvcRequestBuilders.post("/fhir/test-cases/qicore/4-1-1/execution-bundles")
                 .with(user(TEST_USER_ID))
                 .with(csrf())
                 .header(HttpHeaders.AUTHORIZATION, "test-okta")
@@ -423,13 +426,13 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
                   FhirContext.forR4()
                       .newJsonParser()
                       .parseResource(Bundle.class, dto.getTestCases().get(1).getJson());
-              assertThat(returnedBundle.getEntry().size(), is(bundle.getEntry().size()));
+              assertThat(returnedBundle.getEntry().size(), is(testCaseBundle.getEntry().size()));
               assertTrue(
                   returnedBundle
                       .getEntry()
                       .get(0)
                       .getResource()
-                      .equalsDeep(bundle.getEntry().get(0).getResource()));
+                      .equalsDeep(testCaseBundle.getEntry().get(0).getResource()));
             })
         .andExpect(status().isOk());
 
@@ -469,7 +472,7 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     // Act
     mockMvc
         .perform(
-            MockMvcRequestBuilders.post("/fhir/test-cases/qicore/4.1.1/execution-bundles")
+            MockMvcRequestBuilders.post("/fhir/test-cases/qicore/4-1-1/execution-bundles")
                 .with(user(TEST_USER_ID))
                 .with(csrf())
                 .header(HttpHeaders.AUTHORIZATION, "test-okta")
@@ -482,6 +485,72 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
     // Assert
     verify(fhirModelFactory, times(1)).parseForModel(any(), anyString());
     verify(validationService, times(0))
+        .findResourcesWithInvalidReferences(any(FhirContext.class), any(Bundle.class));
+  }
+
+  @Test
+  void testExecutionBundleHandlesMalformedModifiedBundle() throws Exception {
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn(TEST_USER_ID);
+
+    // Arrange
+    String testCaseJsonWithInvalidReference = testCaseJson.replace("Patient\\/1", "Patient\\/nope");
+
+    Bundle bundleWithInvalidReference =
+        FhirContext.forR4()
+            .newJsonParser()
+            .parseResource(Bundle.class, testCaseJsonWithInvalidReference);
+
+    List<TestCase> testCases =
+        List.of(
+            TestCase.builder()
+                .id("test-case-invalid-refs")
+                .patientId(UUID.randomUUID())
+                .title("Test Case with Invalid References")
+                .series("HAPPY_PATH")
+                .json(testCaseJsonWithInvalidReference)
+                .build());
+
+    // Mock the factory to return our test bundle
+    when(fhirModelFactory.parseForModel(any(), eq(testCaseJsonWithInvalidReference)))
+        .thenReturn(bundleWithInvalidReference);
+    when(fhirModelFactory.getJsonParserForModel(any())).thenReturn(parser);
+    when(fhirModelFactory.getContextForModel(any())).thenReturn(FhirContext.forR4());
+    when(parser.encodeResourceToString(any())).thenThrow(new DataFormatException());
+
+    when(validationService.findResourcesWithInvalidReferences(
+            any(FhirContext.class), eq(bundleWithInvalidReference)))
+        .thenReturn(
+            Set.of(
+                bundleWithInvalidReference
+                    .getEntry()
+                    .get(0)
+                    .getResource())); // First entry has invalid reference
+
+    // Act
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/fhir/test-cases/qicore/4-1-1/execution-bundles")
+                .with(user(TEST_USER_ID))
+                .with(csrf())
+                .header(HttpHeaders.AUTHORIZATION, "test-okta")
+                .content(mapper.writeValueAsString(testCases))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andDo(
+            (result) -> {
+              String responseContent = result.getResponse().getContentAsString();
+              assertThat(responseContent, is(notNullValue()));
+              TestCaseExecutionBundlesDTO dto =
+                  mapper.readValue(responseContent, TestCaseExecutionBundlesDTO.class);
+              assertThat(dto.getTestCases().size(), is(0));
+              assertThat(dto.getModifiedTestCaseIds().size(), is(1));
+              assertTrue(dto.getModifiedTestCaseIds().contains("test-case-invalid-refs"));
+            })
+        .andExpect(status().isOk());
+
+    // Assert
+    verify(fhirModelFactory, times(1)).parseForModel(any(), anyString());
+    verify(validationService, times(1))
         .findResourcesWithInvalidReferences(any(FhirContext.class), any(Bundle.class));
   }
 }

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/ResourceValidationServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/ResourceValidationServiceTest.java
@@ -67,6 +67,9 @@ class ResourceValidationServiceTest {
         .addProfile("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure");
     procedure.setStatus(Procedure.ProcedureStatus.COMPLETED);
     procedure.setSubject(new Reference("Patient/pat-1"));
+    Procedure.ProcedurePerformerComponent performer = new Procedure.ProcedurePerformerComponent();
+    performer.setActor(new Reference("Patient/pat-1"));
+    procedure.addPerformer(performer);
     bundleWithValidResources.addEntry().setResource(procedure);
 
     // Duplicate Bundle and mutate Resource to have invalid Reference
@@ -76,13 +79,10 @@ class ResourceValidationServiceTest {
         .setResource(procedure.copy().setSubject(new Reference("Patient/different-patient")));
 
     // Duplicate Bundle and mutate Resource to have invalid nested Reference
-    Procedure.ProcedurePerformerComponent performer = new Procedure.ProcedurePerformerComponent();
-    performer.setActor(new Reference("Practitioner/non-existent"));
-
     bundleWithInvalidNestedResources = bundleWithValidResources.copy();
-    bundleWithInvalidNestedResources
-        .addEntry()
-        .setResource(procedure.copy().addPerformer(performer));
+    ((Procedure) bundleWithInvalidNestedResources.getEntry().get(1).getResource())
+        .setPerformer(
+            List.of(performer.copy().setActor(new Reference("Practitioner/non-existent"))));
   }
 
   @Test

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/ResourceValidationServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/ResourceValidationServiceTest.java
@@ -6,11 +6,13 @@ import ca.uhn.fhir.util.OperationOutcomeUtil;
 import gov.cms.madie.madiefhirservice.constants.UriConstants;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Procedure;
+import org.hl7.fhir.r4.model.Reference;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,12 +23,13 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +37,9 @@ class ResourceValidationServiceTest {
 
   @Spy static FhirContext fhirContext;
   @Spy static FhirContext r5FhirContext;
+  private static Bundle bundleWithValidResources;
+  private static Bundle bundleWithInvalidResources;
+  private static Bundle bundleWithInvalidNestedResources;
 
   @InjectMocks ResourceValidationService validationService;
 
@@ -41,6 +47,42 @@ class ResourceValidationServiceTest {
   public static void setup() {
     fhirContext = FhirContext.forR4();
     r5FhirContext = FhirContext.forR5();
+
+    // Arrange
+    bundleWithValidResources = new Bundle();
+    bundleWithValidResources.setId("test-bundle");
+    bundleWithValidResources.setType(Bundle.BundleType.COLLECTION);
+
+    Patient patient = new Patient();
+    patient.setId("Patient/pat-1");
+    patient
+        .getMeta()
+        .addProfile("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient");
+    bundleWithValidResources.addEntry().setResource(patient);
+
+    Procedure procedure = new Procedure();
+    procedure.setId("Procedure/proc-1");
+    procedure
+        .getMeta()
+        .addProfile("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure");
+    procedure.setStatus(Procedure.ProcedureStatus.COMPLETED);
+    procedure.setSubject(new Reference("Patient/pat-1"));
+    bundleWithValidResources.addEntry().setResource(procedure);
+
+    // Duplicate Bundle and mutate Resource to have invalid Reference
+    bundleWithInvalidResources = bundleWithValidResources.copy();
+    bundleWithInvalidResources
+        .addEntry()
+        .setResource(procedure.copy().setSubject(new Reference("Patient/different-patient")));
+
+    // Duplicate Bundle and mutate Resource to have invalid nested Reference
+    Procedure.ProcedurePerformerComponent performer = new Procedure.ProcedurePerformerComponent();
+    performer.setActor(new Reference("Practitioner/non-existent"));
+
+    bundleWithInvalidNestedResources = bundleWithValidResources.copy();
+    bundleWithInvalidNestedResources
+        .addEntry()
+        .setResource(procedure.copy().addPerformer(performer));
   }
 
   @Test
@@ -219,7 +261,7 @@ class ResourceValidationServiceTest {
           (OperationOutcome) validationService.validateBundleResourcesIdValid(fhirContext, bundle);
       assertThat(output, is(notNullValue()));
       assertThat(output.hasIssue(), is(true));
-      assertEquals(output.getIssueFirstRep().getDiagnostics(), "All resources must have an Id");
+      assertThat(output.getIssueFirstRep().getDiagnostics(), is("All resources must have an Id"));
     }
   }
 
@@ -481,5 +523,48 @@ class ResourceValidationServiceTest {
     assertThat(
         ((org.hl7.fhir.r5.model.OperationOutcome) output).getIssue().get(3).getDiagnostics(),
         is(equalTo("test-error2")));
+  }
+
+  @Test
+  void testFindResourcesWithInvalidReferences() {
+    // Act
+    List<IBaseResource> invalidResources =
+        validationService
+            .findResourcesWithInvalidReferences(fhirContext, bundleWithInvalidResources)
+            .stream()
+            .toList();
+
+    // Assert
+    assertThat(invalidResources.size(), is(equalTo(1)));
+    assertThat(invalidResources.get(0).getIdElement().toString(), is(equalTo("Procedure/proc-1")));
+  }
+
+  @Test
+  void testValidateReferenceInBackboneElementValid() {
+    // Act
+    List<IBaseResource> invalidResources =
+        validationService
+            .findResourcesWithInvalidReferences(fhirContext, bundleWithInvalidNestedResources)
+            .stream()
+            .toList();
+
+    // Assert
+    assertThat(invalidResources.size(), is(equalTo(1)));
+    assertThat(invalidResources.get(0).getIdElement().toString(), is(equalTo("Procedure/proc-1")));
+  }
+
+  @Test
+  void testValidateBundleWithNoEntries() {
+    // Arrange
+    Bundle bundle = new Bundle();
+    bundle.setId("empty-bundle");
+    bundle.setType(Bundle.BundleType.COLLECTION);
+
+    // Act
+    Set<IBaseResource> invalidResources =
+        validationService.findResourcesWithInvalidReferences(fhirContext, bundle);
+
+    // Assert
+    assertTrue(invalidResources.isEmpty());
   }
 }

--- a/src/test/resources/testCaseBundles/validTestCase.json
+++ b/src/test/resources/testCaseBundles/validTestCase.json
@@ -42,9 +42,10 @@
       }
     }
   }, {
-    "fullUrl": "http:\/\/local\/Patient",
+    "fullUrl": "http:\/\/local\/Patient\/1",
     "resource": {
       "resourceType": "Patient",
+      "id": "1",
       "text": {
         "status": "generated",
         "div": "<div xmlns=\"http:\/\/www.w3.org\/1999\/xhtml\">Lizzy Health<\/div>"


### PR DESCRIPTION
## MADiE FHIR SERVICE

Jira Ticket: [MAT-9577](https://jira.cms.gov/browse/MAT-9577)
(Optional) Related Tickets:

### Summary

Prepares Test Case Bundles for Execution.

Accepts one or more `TestCase`s. If a Bundle contains a Resource with an invalid reference, the full Resource is removed from the Bundle. A reference is considered invalid if it cannot be resolved within the Bundle.

Returns a DTO containing modified Bundles as Strings and their associated Test Case IDs.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
