### PR TITLE
MAT-9962 allow invalid references in patient resource for execute inv…

### DIFF
--- a/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
@@ -127,6 +127,7 @@ public class TestCaseBundleController {
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<TestCaseExecutionBundlesDTO> getTestCaseExecutionBundle(
       @PathVariable("model") String modelVersion,
+      @RequestParam(defaultValue = "false") boolean allowInvalidRefsForPatient,
       @RequestBody List<TestCase> testCases,
       HttpEntity<String> request) {
     final ModelType modelType = QICORE_VERSION_MODELTYPE_MAP.get(modelVersion);
@@ -145,7 +146,14 @@ public class TestCaseBundleController {
       List<Bundle.BundleEntryComponent> validResources =
           ((Bundle) bundle)
               .getEntry().stream()
-                  .filter(entry -> !resourcesWithInvalidReferences.contains(entry.getResource()))
+                  .filter(
+                      entry -> {
+                        if (resourcesWithInvalidReferences.contains(entry.getResource())) {
+                          return allowInvalidRefsForPatient
+                              && "Patient".equals(entry.getResource().fhirType());
+                        }
+                        return true;
+                      })
                   .toList();
 
       if (validResources.size() != ((Bundle) bundle).getEntry().size()) {

--- a/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleController.java
@@ -149,6 +149,7 @@ public class TestCaseBundleController {
                   .filter(
                       entry -> {
                         if (resourcesWithInvalidReferences.contains(entry.getResource())) {
+                          // do not filter Patient resource if allowInvalidRefsForPatient is true
                           return allowInvalidRefsForPatient
                               && "Patient".equals(entry.getResource().fhirType());
                         }

--- a/src/main/java/gov/cms/madie/madiefhirservice/resources/ValidationController.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/resources/ValidationController.java
@@ -22,10 +22,7 @@ import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static gov.cms.madie.madiefhirservice.utils.ModelEndpointMap.QICORE_VERSION_MODELTYPE_MAP;
 
@@ -49,7 +46,9 @@ public class ValidationController {
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   public HapiOperationOutcome validateBundleByModel(
-      @PathVariable("model") String modelVersion, HttpEntity<String> request) {
+      @PathVariable("model") String modelVersion,
+      @RequestParam(defaultValue = "false") boolean lenientPatientRefs,
+      HttpEntity<String> request) {
     final ModelType modelType = QICORE_VERSION_MODELTYPE_MAP.get(modelVersion);
     IParser parser = validatorFactory.getJsonParserForModel(modelType);
 
@@ -78,7 +77,8 @@ public class ValidationController {
     IBaseOperationOutcome validIdsOutcome =
         validationService.validateBundleResourcesIdValid(fhirContext, bundle);
     IBaseOperationOutcome validReferencesOutcome =
-        validationService.validateBundleReferencesForExecution(fhirContext, bundle);
+        validationService.validateBundleReferencesForExecution(
+            fhirContext, bundle, lenientPatientRefs);
 
     ValidationResult result = fhirValidator.validateWithResult(bundle);
 

--- a/src/main/java/gov/cms/madie/madiefhirservice/services/ResourceValidationService.java
+++ b/src/main/java/gov/cms/madie/madiefhirservice/services/ResourceValidationService.java
@@ -112,7 +112,7 @@ public class ResourceValidationService {
    * @return HAPI BaseOperationOutcome with warnings for invalid references.
    */
   public IBaseOperationOutcome validateBundleReferencesForExecution(
-      FhirContext fhirContext, IBaseBundle bundleResource) {
+      FhirContext fhirContext, IBaseBundle bundleResource, boolean lenientPatientRefs) {
     if (bundleResource == null) {
       throw new IllegalArgumentException("Bundle resource cannot be null");
     }
@@ -127,24 +127,27 @@ public class ResourceValidationService {
     Set<IBaseResource> resourcesWithInvalidReferences =
         findResourcesWithInvalidReferences(fhirContext, resources);
 
-    // Add a warning issue to the OperationOutcome for each resource with invalid references,
-    // but do not fail validation since this is only used to notify users of which resources
-    // will be excluded from execution of the test case.
+    // Add an issue to the OperationOutcome for each resource with invalid references.
+    // If lenientPatientRefs is true, use a warning to notify users; otherwise use an error
+    // to exclude the resource from execution of the test case.
+    final String severity = lenientPatientRefs ? "warning" : "error";
+    final String message =
+        lenientPatientRefs
+            ? "Resource [%s] contains a reference that does not resolve within the bundle"
+            : "Resource [%s] will not be included in execution "
+                + "because one or more references do not resolve within the bundle.";
     resourcesWithInvalidReferences.forEach(
-        resource -> {
-          OperationOutcomeUtil.addIssue(
-              fhirContext,
-              operationOutcome,
-              "warning",
-              ("Resource [%s] will not be included in execution "
-                      + "because one or more references do not resolve within the bundle.")
-                  .formatted(
-                      resource.getIdElement().getResourceType()
-                          + "/"
-                          + resource.getIdElement().getIdPart()),
-              null,
-              "invalid");
-        });
+        resource ->
+            OperationOutcomeUtil.addIssue(
+                fhirContext,
+                operationOutcome,
+                severity,
+                message.formatted(
+                    resource.getIdElement().getResourceType()
+                        + "/"
+                        + resource.getIdElement().getIdPart()),
+                null,
+                "invalid"));
     return operationOutcome;
   }
 

--- a/src/test/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/resources/TestCaseBundleControllerMvcTest.java
@@ -491,6 +491,79 @@ class TestCaseBundleControllerMvcTest implements ResourceFileUtil {
   }
 
   @Test
+  void testExecutionBundleAllowInvalidRefsForPatientKeepsPatientFiltersOthers() throws Exception {
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn(TEST_USER_ID);
+
+    // Arrange - both Patient and Encounter have invalid references
+    String testCaseJsonWithInvalidReference = testCaseJson.replace("Patient\\/1", "Patient\\/nope");
+    Bundle bundleWithInvalidReference =
+        FhirContext.forR4()
+            .newJsonParser()
+            .parseResource(Bundle.class, testCaseJsonWithInvalidReference);
+
+    List<TestCase> testCases =
+        List.of(
+            TestCase.builder()
+                .id("test-case-invalid-refs")
+                .patientId(UUID.randomUUID())
+                .title("Test Case with Invalid References")
+                .series("HAPPY_PATH")
+                .json(testCaseJsonWithInvalidReference)
+                .build());
+
+    // Mock the factory to return our test bundle
+    when(fhirModelFactory.parseForModel(any(), eq(testCaseJsonWithInvalidReference)))
+        .thenReturn(bundleWithInvalidReference);
+    when(fhirModelFactory.getJsonParserForModel(any()))
+        .thenReturn(FhirContext.forR4().newJsonParser());
+    when(fhirModelFactory.getContextForModel(any())).thenReturn(FhirContext.forR4());
+
+    // Both Encounter (index 0) and Patient (index 1) have invalid references
+    when(validationService.findResourcesWithInvalidReferences(
+            any(FhirContext.class), eq(bundleWithInvalidReference)))
+        .thenReturn(
+            Set.of(
+                bundleWithInvalidReference.getEntry().get(0).getResource(),
+                bundleWithInvalidReference.getEntry().get(1).getResource()));
+
+    // Act - with allowInvalidRefsForPatient=true
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post(
+                    "/fhir/test-cases/qicore/4-1-1/execution-bundles?allowInvalidRefsForPatient=true")
+                .with(user(TEST_USER_ID))
+                .with(csrf())
+                .header(HttpHeaders.AUTHORIZATION, "test-okta")
+                .content(mapper.writeValueAsString(testCases))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andDo(
+            (result) -> {
+              String responseContent = result.getResponse().getContentAsString();
+              assertThat(responseContent, is(notNullValue()));
+              TestCaseExecutionBundlesDTO dto =
+                  mapper.readValue(responseContent, TestCaseExecutionBundlesDTO.class);
+              assertThat(dto.getTestCases().size(), is(1));
+              assertThat(dto.getModifiedTestCaseIds().size(), is(1));
+              assertTrue(dto.getModifiedTestCaseIds().contains("test-case-invalid-refs"));
+              Bundle returnedModifiedBundle =
+                  FhirContext.forR4()
+                      .newJsonParser()
+                      .parseResource(Bundle.class, dto.getTestCases().get(0).getJson());
+              // Only Patient should remain (Encounter filtered out)
+              assertThat(returnedModifiedBundle.getEntry().size(), is(1));
+              assertThat(
+                  returnedModifiedBundle.getEntry().get(0).getResource().fhirType(), is("Patient"));
+            })
+        .andExpect(status().isOk());
+
+    // Assert
+    verify(fhirModelFactory, times(1)).parseForModel(any(), anyString());
+    verify(validationService, times(1))
+        .findResourcesWithInvalidReferences(any(FhirContext.class), any(Bundle.class));
+  }
+
+  @Test
   void testExecutionBundleHandlesMalformedModifiedBundle() throws Exception {
     Principal principal = mock(Principal.class);
     when(principal.getName()).thenReturn(TEST_USER_ID);

--- a/src/test/java/gov/cms/madie/madiefhirservice/resources/ValidationControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/resources/ValidationControllerMvcTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -133,7 +134,7 @@ class ValidationControllerMvcTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(new OperationOutcome());
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
     when(validationService.combineOutcomes(any(FhirContext.class), any(), any(), any(), any()))
         .thenReturn(new OperationOutcome());
@@ -174,7 +175,7 @@ class ValidationControllerMvcTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(new OperationOutcome());
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
     when(validationService.combineOutcomes(any(FhirContext.class), any(), any(), any(), any()))
         .thenReturn(operationOutcomeWithIssues);
@@ -216,7 +217,7 @@ class ValidationControllerMvcTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(new OperationOutcome());
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
     when(validationService.combineOutcomes(any(FhirContext.class), any(), any(), any(), any()))
         .thenReturn(new OperationOutcome());
@@ -262,7 +263,7 @@ class ValidationControllerMvcTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(invalidIdErrorOutcome);
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
     OperationOutcome combinedOutcome = new OperationOutcome();
     combinedOutcome.addIssue().setSeverity(OperationOutcome.IssueSeverity.ERROR);

--- a/src/test/java/gov/cms/madie/madiefhirservice/resources/ValidationControllerTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/resources/ValidationControllerTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -94,7 +95,8 @@ class ValidationControllerTest implements ResourceFileUtil {
                 .build());
 
     when(entity.getBody()).thenReturn("{\"foo\": \"foo2\" }");
-    HapiOperationOutcome output = validationController.validateBundleByModel(QICORE_4_1_1, entity);
+    HapiOperationOutcome output =
+        validationController.validateBundleByModel(QICORE_4_1_1, false, entity);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(HttpStatus.BAD_REQUEST.value())));
     assertThat(output.isSuccessful(), is(false));
@@ -119,7 +121,8 @@ class ValidationControllerTest implements ResourceFileUtil {
     when(entity.getBody()).thenReturn("{\"foo\": \"foo2\" }");
 
     // when
-    HapiOperationOutcome output = validationController.validateBundleByModel(QICORE_4_1_1, entity);
+    HapiOperationOutcome output =
+        validationController.validateBundleByModel(QICORE_4_1_1, false, entity);
 
     // then
     assertThat(output, is(notNullValue()));
@@ -142,7 +145,7 @@ class ValidationControllerTest implements ResourceFileUtil {
     // when/then
     assertThrows(
         HapiJsonException.class,
-        () -> validationController.validateBundleByModel(QICORE_4_1_1, entity));
+        () -> validationController.validateBundleByModel(QICORE_4_1_1, false, entity));
   }
 
   @Test
@@ -165,7 +168,7 @@ class ValidationControllerTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(new OperationOutcome());
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
 
     ValidationResult result = Mockito.mock(ValidationResult.class);
@@ -177,7 +180,8 @@ class ValidationControllerTest implements ResourceFileUtil {
         .thenReturn(false);
 
     // when
-    HapiOperationOutcome output = validationController.validateBundleByModel(QICORE_4_1_1, entity);
+    HapiOperationOutcome output =
+        validationController.validateBundleByModel(QICORE_4_1_1, false, entity);
 
     // then
     assertThat(output, is(notNullValue()));
@@ -206,7 +210,7 @@ class ValidationControllerTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(new OperationOutcome());
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
     OperationOutcome outcome = new OperationOutcome();
     outcome.addIssue().setSeverity(OperationOutcome.IssueSeverity.ERROR);
@@ -218,7 +222,7 @@ class ValidationControllerTest implements ResourceFileUtil {
         .thenReturn("{ \"resourceType\": \"OperationOutcome\" }");
     assertThrows(
         HapiJsonException.class,
-        () -> validationController.validateBundleByModel(QICORE_4_1_1, entity));
+        () -> validationController.validateBundleByModel(QICORE_4_1_1, false, entity));
   }
 
   @Test
@@ -242,7 +246,7 @@ class ValidationControllerTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(new OperationOutcome());
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
 
     when(parser.encodeResourceToString(any(OperationOutcome.class)))
@@ -260,7 +264,8 @@ class ValidationControllerTest implements ResourceFileUtil {
     when(validationService.isSuccessful(any(FhirContext.class), any(OperationOutcome.class)))
         .thenReturn(false);
 
-    HapiOperationOutcome output = validationController.validateBundleByModel(QICORE_4_1_1, entity);
+    HapiOperationOutcome output =
+        validationController.validateBundleByModel(QICORE_4_1_1, false, entity);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(HttpStatus.OK.value())));
     assertThat(output.isSuccessful(), is(false));
@@ -288,7 +293,7 @@ class ValidationControllerTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(new OperationOutcome());
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
     OperationOutcome errorOutcome = new OperationOutcome();
     errorOutcome
@@ -311,7 +316,8 @@ class ValidationControllerTest implements ResourceFileUtil {
     when(validationService.isSuccessful(any(FhirContext.class), any(OperationOutcome.class)))
         .thenReturn(false);
 
-    HapiOperationOutcome output = validationController.validateBundleByModel(QICORE_4_1_1, entity);
+    HapiOperationOutcome output =
+        validationController.validateBundleByModel(QICORE_4_1_1, false, entity);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(HttpStatus.BAD_REQUEST.value())));
     assertThat(output.getOutcomeResponse() instanceof Map, is(true));
@@ -338,7 +344,7 @@ class ValidationControllerTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(new OperationOutcome());
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
     OperationOutcome errorOutcome = new OperationOutcome();
     errorOutcome
@@ -360,7 +366,8 @@ class ValidationControllerTest implements ResourceFileUtil {
     when(validationService.isSuccessful(any(FhirContext.class), any(OperationOutcome.class)))
         .thenReturn(false);
 
-    HapiOperationOutcome output = validationController.validateBundleByModel(QICORE_4_1_1, entity);
+    HapiOperationOutcome output =
+        validationController.validateBundleByModel(QICORE_4_1_1, false, entity);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(HttpStatus.BAD_REQUEST.value())));
     assertThat(output.getOutcomeResponse() instanceof Map, is(true));
@@ -396,7 +403,7 @@ class ValidationControllerTest implements ResourceFileUtil {
         .setDiagnostics("All references must be valid.")
         .setSeverity(OperationOutcome.IssueSeverity.WARNING);
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(warningOutcome);
     when(parser.encodeResourceToString(any(OperationOutcome.class)))
         .thenReturn("{ \"resourceType\": \"OperationOutcome\" }");
@@ -410,7 +417,8 @@ class ValidationControllerTest implements ResourceFileUtil {
     when(validationService.isSuccessful(any(FhirContext.class), any(OperationOutcome.class)))
         .thenReturn(false);
 
-    HapiOperationOutcome output = validationController.validateBundleByModel(QICORE_4_1_1, entity);
+    HapiOperationOutcome output =
+        validationController.validateBundleByModel(QICORE_4_1_1, false, entity);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(HttpStatus.OK.value())));
     assertThat(output.getOutcomeResponse() instanceof Map, is(true));
@@ -437,7 +445,7 @@ class ValidationControllerTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(new OperationOutcome());
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
     when(validationService.combineOutcomes(any(FhirContext.class), any(), any(), any(), any()))
         .thenReturn(new OperationOutcome());
@@ -449,7 +457,8 @@ class ValidationControllerTest implements ResourceFileUtil {
     when(fhirValidator.validateWithResult(any(IBaseResource.class))).thenReturn(result);
     when(parser.encodeResourceToString(any(OperationOutcome.class)))
         .thenReturn("{ \"resourceType\": \"OperationOutcome\" }");
-    HapiOperationOutcome output = validationController.validateBundleByModel(QICORE_4_1_1, entity);
+    HapiOperationOutcome output =
+        validationController.validateBundleByModel(QICORE_4_1_1, false, entity);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(HttpStatus.OK.value())));
     assertThat(output.isSuccessful(), is(true));
@@ -473,7 +482,7 @@ class ValidationControllerTest implements ResourceFileUtil {
             any(FhirContext.class), any(IBaseBundle.class)))
         .thenReturn(new OperationOutcome());
     when(validationService.validateBundleReferencesForExecution(
-            any(FhirContext.class), any(IBaseBundle.class)))
+            any(FhirContext.class), any(IBaseBundle.class), anyBoolean()))
         .thenReturn(new OperationOutcome());
     when(validationService.combineOutcomes(any(FhirContext.class), any(), any(), any(), any()))
         .thenReturn(new OperationOutcome());
@@ -486,7 +495,8 @@ class ValidationControllerTest implements ResourceFileUtil {
     when(parser.encodeResourceToString(any(OperationOutcome.class)))
         .thenReturn("{ \"resourceType\": \"OperationOutcome\" }");
 
-    HapiOperationOutcome output = validationController.validateBundleByModel(QICORE_6_0_0, entity);
+    HapiOperationOutcome output =
+        validationController.validateBundleByModel(QICORE_6_0_0, false, entity);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(HttpStatus.OK.value())));
     assertThat(output.isSuccessful(), is(true));

--- a/src/test/java/gov/cms/madie/madiefhirservice/services/ResourceValidationServiceTest.java
+++ b/src/test/java/gov/cms/madie/madiefhirservice/services/ResourceValidationServiceTest.java
@@ -574,7 +574,7 @@ class ResourceValidationServiceTest {
     // Act
     IBaseOperationOutcome baseOperationOutcome =
         validationService.validateBundleReferencesForExecution(
-            fhirContext, bundleWithInvalidNestedResources);
+            fhirContext, bundleWithInvalidNestedResources, true);
 
     // Assert
     OperationOutcome outcome = (OperationOutcome) baseOperationOutcome;
@@ -583,7 +583,7 @@ class ResourceValidationServiceTest {
     assertThat(
         outcome.getIssue().get(0).getDiagnostics(),
         is(
-            "Resource [Procedure/proc-1] will not be included in execution because one or more references do not resolve within the bundle."));
+            "Resource [Procedure/proc-1] contains a reference that does not resolve within the bundle"));
   }
 
   @Test
@@ -601,7 +601,7 @@ class ResourceValidationServiceTest {
 
     // Act
     IBaseOperationOutcome outcome =
-        validationService.validateBundleReferencesForExecution(fhirContext, bundle);
+        validationService.validateBundleReferencesForExecution(fhirContext, bundle, false);
 
     // Assert
     assertThat(validationService.isSuccessful(fhirContext, outcome), is(true));
@@ -613,10 +613,10 @@ class ResourceValidationServiceTest {
     // Act
     IBaseOperationOutcome outcome =
         validationService.validateBundleReferencesForExecution(
-            fhirContext, bundleWithInvalidNestedResources);
+            fhirContext, bundleWithInvalidNestedResources, false);
 
     // Assert
-    assertThat(validationService.isSuccessful(fhirContext, outcome), is(true));
+    assertThat(validationService.isSuccessful(fhirContext, outcome), is(false));
     assertThat(((OperationOutcome) outcome).getIssue().size(), is(equalTo(1)));
     assertThat(
         ((OperationOutcome) outcome).getIssue().get(0).getDiagnostics(),
@@ -629,7 +629,7 @@ class ResourceValidationServiceTest {
     // Act & Assert
     assertThrows(
         IllegalArgumentException.class,
-        () -> validationService.validateBundleReferencesForExecution(fhirContext, null));
+        () -> validationService.validateBundleReferencesForExecution(fhirContext, null, false));
   }
 
   @Test
@@ -641,6 +641,6 @@ class ResourceValidationServiceTest {
     // Act & Assert
     assertThrows(
         IllegalArgumentException.class,
-        () -> validationService.validateBundleReferencesForExecution(null, bundle));
+        () -> validationService.validateBundleReferencesForExecution(null, bundle, false));
   }
 }


### PR DESCRIPTION
…alid test case config. Also, update validation severity based on it

## MADiE FHIR SERVICE

Jira Ticket: [MAT-9962](https://jira.cms.gov/browse/MAT-9962)
(Optional) Related Tickets:

### Summary
- Allow invalid references in patient resource for execute invalid test case config. 
- Update validation severity and message based on execute invalid test case config

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
